### PR TITLE
Handling virtualkeyboard placement

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -3,7 +3,14 @@
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		
+		<!-- Challenge: Show the toolbar when the virtual keyboard is visible.-->
+		<!-- Solution: enable the VirtualKeyboard: overlaysContent property -->
+		<!-- Caveat: This only works in Chrome (Android) so far -->
+		<meta 
+			name="viewport" 
+			content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content"
+		>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover" spellcheck="false">

--- a/src/lib/ListBlock.svelte
+++ b/src/lib/ListBlock.svelte
@@ -11,6 +11,7 @@
   data-type="block"
   data-index={path.at(-1)}
   style="anchor-name: --{path.join('-')};"
+  class='p-10 max-w-screen-md mx-auto'
 >
   <Container class="list" path={[...path, 'items']}>
     <!-- NOTE: We only allow list items inside list  -->

--- a/src/lib/StoryBlock.svelte
+++ b/src/lib/StoryBlock.svelte
@@ -11,13 +11,16 @@
 </script>
 
 <div
-  class="story-block layout-{block.layout} p-2"
+  class="story-block layout-{block.layout} max-w-screen-lg mx-auto w-full"
   data-path={path.join('.')}
   data-type="block"
   data-index={path.at(-1)}
   style="anchor-name: --{path.join('-')};"
 >
-  <div class='non-text-content' contenteditable="false">
+  <div
+    class='non-text-content' 
+    contenteditable="false"
+  >
     <!-- svelte-ignore a11y_img_redundant_alt -->
     <img src={block.image} alt="Random image" />
   </div>
@@ -30,18 +33,28 @@
 
 <style>
   .story-block {
+    container-type: inline-size;
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(min(30ch, 100%), 1fr));
-    gap: var(--s-10);
-    img {
-      width: 100%;
-      height: auto;
-      /* Don't crop SVGs */
-      &[src*=".svg"] {
-        object-fit: contain;
-        object-position: center;
-      }
+    grid-template-columns: 1fr;      
+    /* Apply padding on the sides of the block, but only on devices that need it, e.g. iPhone with notch */
+    /* Learn more about this technique here: https://kulturbanause.de/blog/websites-fuer-das-iphone-x-optimieren-weisse-balken-entfernen-viewport-anpassen-safe-area-festlegen/ */
+    padding-inline-start: max(var(--s-10), env(safe-area-inset-left, 0px));
+    padding-inline-end: max(var(--s-10), env(safe-area-inset-right, 0px));
+    padding-block-start: max(var(--s-10), env(safe-area-inset-top, 0px));
+    padding-block-end: max(var(--s-10), env(safe-area-inset-bottom, 0px));
+    @media (min-width: 680px) {
+      grid-template-columns: 1fr 1fr;      
     }
+    /* gap: var(--s-10); */
+  }
+  .story-block img {
+    width: 100%;
+    height: auto;
+  }
+  /* Don't crop SVGs */
+  .story-block img[src*=".svg"] {
+    object-fit: contain;
+    object-position: center;
   }
 
   .non-text-content {
@@ -50,8 +63,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    min-width: 30ch;
-    @media (max-width: 768px) {
+    min-width: 340px;
+    @media (max-width: 680px) {
       min-width: 100%;
     }
   }
@@ -61,12 +74,14 @@
     align-items: center;
   }
 
-  .story-block.layout-2 > div:first-child {
-    order: 2;
-  }
-
-  .story-block.layout-2 > div:last-child {
-    order: 1;
+  @container (min-width: 680px) {
+    /* on mobile display image on top of text */
+    .story-block.layout-2 > div:first-child {
+      order: 2;
+    }
+    .story-block.layout-2 > div:last-child {
+      order: 1;
+    }
   }
 
   .story-block.layout-3 > div:first-child {

--- a/src/lib/TextToolBar.svelte
+++ b/src/lib/TextToolBar.svelte
@@ -37,7 +37,7 @@
   // Bug report for Safari:
   // https://bugs.webkit.org/show_bug.cgi?id=230225
 
-  
+
   function updateViewport() {
     if (browser) {
       const viewport_height = window.visualViewport?.height || window.innerHeight;
@@ -199,22 +199,23 @@
 
 <style>
   /* only use the javascript visual viewport placement technique when the contenteditable is focused */
-  :global(body:has(:is([contenteditable="true"]):focus)) {
-    .editor-toolbar {
-      top: var(--toolbar-top-position);
-      bottom: auto;
+  @media (max-width: 768px) {
+    :global(body:has(:is([contenteditable="true"]):focus)) {
+      .editor-toolbar {
+        top: var(--toolbar-top-position);
+        bottom: auto;
+      }
     }
   }
 
   .editor-toolbar {
     --toolbar-height: 44px;
     --toolbar-bottom-offset: var(--s-4);
-    height: var(--toolbar-height);
     color: var(--primary-text-color);
     background-color: var(--canvas-fill-color);
     width: fit-content;
     position: fixed;
-    top: var(--toolbar-top-position);
+    top: 50%;
     transform: translateY(-50%);
     left: var(--s-4);
     border-radius: 9999px;
@@ -226,7 +227,7 @@
     transition: all 0.1s ease-in-out 200ms;
     overflow-y: hidden;
 
-    @media (max-width: 768px) {      
+    @media (max-width: 768px) {
       top: auto;
       /* alternative css only approach for Chromium / Android */
       bottom: max(calc(env(keyboard-inset-height, 0px) + var(--toolbar-bottom-offset)), var(--toolbar-bottom-offset));
@@ -234,6 +235,7 @@
       transform: translateX(-50%);
       flex-direction: row;
       max-width: calc(100vw - 2 * var(--s-4));
+      height: var(--toolbar-height);
       overflow-x: auto;
       scrollbar-width: thin;
     }

--- a/src/lib/styles/spacing.css
+++ b/src/lib/styles/spacing.css
@@ -25,6 +25,13 @@
 .m-8   { --m:  var(--s-8) } .ms-8  { --ms: var(--s-8); }  .me-8  { --me: var(--s-8);  } .mbs-8  { --mbs: var(--s-8);  } .mbe-8  { --mbe: var(--s-8);  } .mx-8  { --mx: var(--s-8);  } .my-8  { --my: var(--s-8);  } 
 .m-9   { --m:  var(--s-9) } .ms-9  { --ms: var(--s-9); }  .me-9  { --me: var(--s-9);  } .mbs-9  { --mbs: var(--s-9);  } .mbe-9  { --mbe: var(--s-9);  } .mx-9  { --mx: var(--s-9);  } .my-9  { --my: var(--s-9);  } 
 .m-10  { --m:  var(--s-10)} .ms-10 { --ms: var(--s-10);}  .me-10 { --me: var(--s-10); } .mbs-10 { --mbs: var(--s-10); } .mbe-10 { --mbe: var(--s-10); } .mx-10 { --mx: var(--s-10); } .my-10 { --my: var(--s-10); } 
+.m-auto { margin: auto; }
+.mx-auto { margin-inline: auto; }
+.my-auto { margin-block: auto; }
+.ms-auto { margin-inline-start: auto; }
+.me-auto { margin-inline-end: auto; }
+.mbs-auto { margin-block-start: auto; }
+.mbe-auto { margin-block-end: auto; }
 
 
 /* for less than ~10 spacing values, we use the following approach */
@@ -88,3 +95,16 @@
 .gap-05, .gap-1, .gap-2, .gap-3, .gap-4, .gap-5, .gap-6, .gap-7, .gap-8, .gap-9, .gap-10 { gap: var(--g); }
 .gap-x-05, .gap-x-1, .gap-x-2, .gap-x-3, .gap-x-4, .gap-x-5, .gap-x-6, .gap-x-7, .gap-x-8, .gap-x-9, .gap-x-10 { column-gap: var(--gx); }
 .gap-y-05, .gap-y-1, .gap-y-2, .gap-y-3, .gap-y-4, .gap-y-5, .gap-y-6, .gap-y-7, .gap-y-8, .gap-y-9, .gap-y-10 { row-gap: var(--gy); }
+
+
+
+/* Max-Width */
+.max-w-prose { max-width: 65ch; }
+.max-w-screen-sm { max-width: 640px; }
+.max-w-screen-md { max-width: 768px; }
+.max-w-screen-lg { max-width: 1024px; }
+.max-w-screen-xl { max-width: 1280px; }
+.max-w-screen-2xl { max-width: 1536px; }
+
+/* Width */ 
+.w-full { width: 100%; }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,11 +10,11 @@
   let entry_session = new EntrySession({
     type: 'page',
     title: ['Svedit', []],
-    subtitle: ['A template for building rich content editors with Svelte 5', [
+    subtitle: ['A template for building rich content editors with Svelte 5', [
       [24, 44, 'emphasis']
     ]],
     body: [
-      { type: 'story', layout: 1, image: '/images/editable.svg', title: ['Visual in-place editing', []], description: ['Model your content in JSON, render it with Svelte components, and edit content directly in the layout. You only have to follow a couple of rules to make this work.', []] },
+      { type: 'story', layout: 1, image: '/images/editable.svg', title: ['Visual in‑place editing', []], description: ['Model your content in JSON, render it with Svelte components, and edit content directly in the layout. You only have to follow a couple of rules to make this work.', []] },
       { type: 'story', layout: 2, image: '/images/lightweight.svg', title: ['Minimal viable editor', []], description: ["The reference implementation uses only about 1000 lines of code. That means you'll be able to serve editable web pages, removing the need for a separate Content Management System.", [[100,118, "link", { "href": "https://editable.website"}]]] },
       { type: 'story', layout: 1, image: '/images/nested-blocks-illustration.svg', title: ['Nested blocks', []], description: ['A block can embed a container of other blocks. For instance the list block below has a container of list items.', []] },
       { type: 'story', layout: 2, image: '/images/container-cursors.svg', title: ['Container cursors', []], description: ['They work just like text cursors, but instead of a character position in a string they address a block position in a container.\n\nTry it by selecting a few blocks, then press ↑ or ↓. Press ↵ to insert a new block or ⌫ to delete the block before the cursor.', []] },
@@ -24,7 +24,7 @@
         type: 'list',
         list_style: 'decimal-leading-zero',
         items: [
-          { type: 'list_item', description: ['Images can not yet be selected and changed. We\'ll solve this by making any non-text property selectable on the canvas, and show a popover (e.g. an image selector, or a math formula editor) to make changes, which will then be reflected in the canvas display immediately.' , []] },
+          { type: 'list_item', description: ['Images can not yet be selected and changed. We\'ll solve this by making any non‑text property selectable on the canvas, and show a popover (e.g. an image selector, or a math formula editor) to make changes, which will then be reflected in the canvas display immediately.' , []] },
           { type: 'list_item', description: ['Container selections inside nested blocks (e.g. list items in this list) do not work reliably yet.', []] },
           { type: 'list_item', description: ['Only the latest Chrome is supported at the moment as we rely on CSS Anchor Positioning for overlays.', []] },
           { type: 'list_item', description: ['Full mobile support is considered in our design, but not yet implemented.', []] },
@@ -38,15 +38,16 @@
   <title>Svedit - A rich content editor for Svelte 5</title>
 </svelte:head>
 
-<div class="demo-wrapper pbs-10">
+<div class="demo-wrapper">
   <TextToolBar {entry_session} />
 
-
-  <Svedit {entry_session} editable={true} class='flex-column gap-y-10'>
-    <Text path={['title']} class='heading1' />
-    <Text path={['subtitle']} class='heading3' />
+  <Svedit {entry_session} editable={true} class='flex-column'>
+    <div class='flex-column gap-y-10 p-10 max-w-screen-lg mx-auto w-full'>
+      <Text path={['title']} class='heading1' />
+      <Text path={['subtitle']} class='heading3' />
+    </div>
     <!-- NOTE: non-editable island must have contenteditable="false" and contain some text content, otherwise invalid selections occur. -->
-    <div contenteditable="false" style="background: #eee; opacity: 0.5; padding: 20px;">
+    <div contenteditable="false" style="background: #eee; opacity: 0.5;" class='p-10 max-w-screen-lg mx-auto'>
       <div><div>In this example the title and subtitle above are editable, but this piece of content here is not. Below is a container of Story and List blocks:</div></div>
     </div>
     <Container class="body flex-column gap-y-10" path={['body']}>
@@ -60,10 +61,11 @@
         {/if}
       {/snippet}
     </Container>
-</Svedit>
+  </Svedit>
+
   <hr/>
   
-  <div class='flex-column gap-y-2 my-10'>
+  <div class='flex-column gap-y-2 my-10 w-full max-w-screen-lg mx-auto'>
     <p>Selection:</p>
     <pre class='debug-info p-4'>{JSON.stringify(entry_session.selection || {}, null, '  ')}</pre>
     <p>Entry:</p>
@@ -73,19 +75,7 @@
 
 <style>
   .demo-wrapper {
-    padding-inline: var(--s-10);
-    max-width: 100ch;
-    margin-inline: auto;
-    background: var(--canvas-fill-color);
-
-    /* We want a two column layout for the block container. */
-    /* :global(.body) {
-      display: grid;
-      grid-template-columns: repeat(2, 1fr);
-      gap: 1rem;
-      width: 100%;
-    } */
-
+    /* no paddings or margins here on the body, so Blocks can use the full width (edge to edge layouts) */
   }
   .debug-info {
     text-wrap: wrap;


### PR DESCRIPTION
So after trying like two dozen different techniques I finally found a solution that works well in Chromium (Android) and semi-ok in Safari. In Safari there are temporary placment issues of the toolbar when the viewport shifts (the user scrolls, but the browser doesn't actually scroll the page, but instead moves the visual viewport up / down until the "edge" is reached" ... hard to explain in words … but it's a known issue and there are several bug reports for Safari. The solution for chromium is just a line of css and an additional meta viewport tag attribute.