### PR TITLE
Prevent flickering of cursor jumping from end of placeholder string to start of text property; Fix disappearing caret in Safari

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,9 @@ a simplified version of the markup of `<NodeCursorTrap>` and why it is implement
       Adding a &ZeroWidthSpace; (or any character) here will lead to 2 cursor
       positions (one before, and one after the character)
 
+      Using <wbr> will make it only addressable for ArrowLeft and ArrowRight, but not ArrowUp and ArrowDown.
+      And using <span></span> will not make it addressable at all.
+
       Svedit uses this behavior for node-cursor-traps, and when an
       <AnnotatedTextProperty> is empty.
     -->


### PR DESCRIPTION
Video with before and after behaviour of this fix. 
Note how the cursor is first placed at the end of the placeholder, and then jumps to the front

https://github.com/user-attachments/assets/c897c7b9-b368-4ef4-a450-0ba5e39a0200

