### PR TITLE
Centralize DOM path serialization helpers

### DIFF
--- a/src/lib/AnnotatedTextProperty.svelte
+++ b/src/lib/AnnotatedTextProperty.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { getContext } from 'svelte';
+	import { serialize_dom_path } from './dom_path.js';
 	import { char_slice, get_char_length, snake_to_pascal, get_selection_range } from './utils.js';
 
 	/** @import { AnnotatedTextPropertyProps, Annotation, Fragment, SelectionRange } from './types.d.ts'; */
@@ -106,7 +107,7 @@
 <svelte:element
 	this={tag}
 	data-type="text"
-	data-path={path.join('.')}
+	data-path={serialize_dom_path(path)}
 	style="anchor-name: --{path.join('-')};{style}"
 	class="text svedit-selectable {css_class}"
 	class:empty={is_empty}

--- a/src/lib/CustomProperty.svelte
+++ b/src/lib/CustomProperty.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { getContext } from 'svelte';
+	import { serialize_dom_path } from './dom_path.js';
 
 	/** @import { CustomPropertyProps } from './types.d.ts'; */
 	const svedit = getContext('svedit');
@@ -12,7 +13,7 @@
 	this={tag}
 	class={css_class}
 	data-type="property"
-	data-path={path.join('.')}
+	data-path={serialize_dom_path(path)}
 	style="anchor-name: --{path.join('-')};{style ? ` ${style}` : ''}"
 	{...rest}
 >

--- a/src/lib/Node.svelte
+++ b/src/lib/Node.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { getContext } from 'svelte';
+	import { serialize_dom_path } from './dom_path.js';
 
 	/** @import { NodeProps } from './types.d.ts'; */
 
@@ -24,7 +25,7 @@
 	this={tag}
 	class={css_class}
 	data-node-id={node.id}
-	data-path={path.join('.')}
+	data-path={serialize_dom_path(path)}
 	data-type="node"
 	style="position: relative; anchor-name: --{path.join('-')};{style}"
 	{...rest}

--- a/src/lib/NodeArrayProperty.svelte
+++ b/src/lib/NodeArrayProperty.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { getContext } from 'svelte';
 	import UnknownNode from './UnknownNode.svelte';
+	import { serialize_dom_path } from './dom_path.js';
 	import { snake_to_pascal } from './utils.js';
 
 	/** @import { NodeArrayPropertyProps } from './types.d.ts'; */
@@ -18,7 +19,14 @@
 	);
 </script>
 
-<svelte:element this={tag} class={css_class} data-type="node_array" data-path={path.join('.')} style={style} {...rest}>
+<svelte:element
+	this={tag}
+	class={css_class}
+	data-type="node_array"
+	data-path={serialize_dom_path(path)}
+	style={style}
+	{...rest}
+>
 	{#if nodes.length === 0 && svedit.editable}
 		<!--
 		Experimental: We'll let .empty-node-array act like a node, so the existing
@@ -28,7 +36,7 @@
 		-->
 		<div
 			class="node empty-node-array"
-			data-path={[...path, 0].join('.')}
+			data-path={serialize_dom_path([...path, 0])}
 			data-type="node"
 			style="anchor-name: --{[...path, 0].join(
 				'-'

--- a/src/lib/Svedit.svelte
+++ b/src/lib/Svedit.svelte
@@ -6,6 +6,7 @@
 		utf16_to_char_offset,
 		char_to_utf16_offset
 	} from './utils.js';
+	import { deserialize_dom_path, serialize_dom_path } from './dom_path.js';
 
 	/** @import {
 	 *   SveditProps,
@@ -759,7 +760,7 @@ ${fallback_html}`;
 				console.log('No corresponding node found for after-node-cursor-trap');
 				return null;
 			}
-			const node_path = /** @type {DocumentPath} */ (node.dataset.path.split('.'));
+			const node_path = /** @type {DocumentPath} */ (deserialize_dom_path(node.dataset.path));
 			const node_index = parseInt(String(node_path.at(-1)), 10);
 
 			return {
@@ -776,7 +777,7 @@ ${fallback_html}`;
 			const node_array_el = /** @type {HTMLElement} */ (
 				position_zero_cursor_trap.closest('[data-type="node_array"]')
 			);
-			const node_array_path = node_array_el.dataset.path.split('.');
+			const node_array_path = deserialize_dom_path(node_array_el.dataset.path);
 			return {
 				type: 'node',
 				path: node_array_path,
@@ -799,8 +800,8 @@ ${fallback_html}`;
 			return null;
 		}
 
-		let focus_root_path = focus_root.dataset.path.split('.');
-		let anchor_root_path = anchor_root.dataset.path.split('.');
+		let focus_root_path = deserialize_dom_path(focus_root.dataset.path);
+		let anchor_root_path = deserialize_dom_path(anchor_root.dataset.path);
 		let focus_node_depth = focus_root_path.length;
 		let anchor_node_depth = anchor_root_path.length;
 
@@ -808,22 +809,23 @@ ${fallback_html}`;
 		if (focus_root_path.length > anchor_root_path.length) {
 			focus_root = focus_root.parentElement.closest('[data-path][data-type="node"]');
 			if (!focus_root) return null;
-			focus_root_path = focus_root.dataset.path.split('.');
+			focus_root_path = deserialize_dom_path(focus_root.dataset.path);
 		} else if (anchor_root_path.length > focus_root_path.length) {
 			anchor_root = anchor_root.parentElement.closest('[data-path][data-type="node"]');
 			if (!anchor_root) return null;
-			anchor_root_path = anchor_root.dataset.path.split('.');
+			anchor_root_path = deserialize_dom_path(anchor_root.dataset.path);
 		}
 
-		const is_same_node_array =
-			focus_root_path.slice(0, -1).join('.') === anchor_root_path.slice(0, -1).join('.');
+		const focus_root_parent_path_key = serialize_dom_path(focus_root_path.slice(0, -1));
+		const anchor_root_parent_path_key = serialize_dom_path(anchor_root_path.slice(0, -1));
+		const is_same_node_array = focus_root_parent_path_key === anchor_root_parent_path_key;
 		if (!is_same_node_array) {
 			console.log('invalid selection, not same node_array');
 			return null;
 		}
 
-		let anchor_offset = parseInt(anchor_root_path.at(-1));
-		let focus_offset = parseInt(focus_root_path.at(-1));
+		let anchor_offset = parseInt(String(anchor_root_path.at(-1)), 10);
+		let focus_offset = parseInt(String(focus_root_path.at(-1)), 10);
 
 		// Check if it's a backwards selection
 		const is_backwards = __is_dom_selection_backwards();
@@ -885,7 +887,7 @@ ${fallback_html}`;
 		if (focus_root === anchor_root) {
 			return {
 				type: 'property',
-				path: focus_root.dataset.path.split('.')
+				path: deserialize_dom_path(focus_root.dataset.path)
 			};
 		}
 		return null;
@@ -948,7 +950,7 @@ ${fallback_html}`;
 			return null;
 		}
 
-		const path = focus_root.dataset.path.split('.');
+		const path = deserialize_dom_path(focus_root.dataset.path);
 
 		if (!path) return null;
 
@@ -1039,8 +1041,9 @@ ${fallback_html}`;
 	}
 
 	function __get_node_element(node_array_path, node_offset) {
+		const node_array_path_key = serialize_dom_path(node_array_path);
 		const node_array_el = canvas_el.querySelector(
-			`[data-path="${node_array_path}"][data-type="node_array"]`
+			`[data-path="${node_array_path_key}"][data-type="node_array"]`
 		);
 		if (!node_array_el) return null;
 
@@ -1052,7 +1055,8 @@ ${fallback_html}`;
 
 	function __render_node_selection() {
 		const selection = /** @type {NodeSelection} */ (session.selection);
-		const node_array_path = selection.path.join('.');
+		const node_array_path = selection.path;
+		const node_array_path_key = serialize_dom_path(node_array_path);
 		let is_collapsed = selection.anchor_offset === selection.focus_offset;
 		let is_backward = !is_collapsed && selection.anchor_offset > selection.focus_offset;
 
@@ -1123,7 +1127,7 @@ ${fallback_html}`;
 
 		// Ensure the node_array is focused
 		const node_array_el = canvas_el.querySelector(
-			`[data-path="${node_array_path}"][data-type="node_array"]`
+			`[data-path="${node_array_path_key}"][data-type="node_array"]`
 		);
 		if (node_array_el) {
 			node_array_el.focus();
@@ -1141,9 +1145,10 @@ ${fallback_html}`;
 
 	function __render_property_selection() {
 		const selection = session.selection;
+		const selection_path_key = serialize_dom_path(selection.path);
 		// The element that holds the property
 		const el = canvas_el.querySelector(
-			`[data-path="${selection.path.join('.')}"][data-type="property"]`
+			`[data-path="${selection_path_key}"][data-type="property"]`
 		);
 		const cursor_trap_selectable = el.querySelector('.svedit-selectable');
 		const range = window.document.createRange();
@@ -1166,9 +1171,10 @@ ${fallback_html}`;
 
 	function __render_text_selection() {
 		const selection = /** @type {any} */ (session.selection);
+		const selection_path_key = serialize_dom_path(selection.path);
 		// The element that holds the annotated string
 		const el = canvas_el.querySelector(
-			`[data-path="${selection.path.join('.')}"][data-type="text"]`
+			`[data-path="${selection_path_key}"][data-type="text"]`
 		);
 		const empty_text = session.get(selection.path).text.length === 0;
 		const dom_selection = window.getSelection();

--- a/src/lib/dom_path.js
+++ b/src/lib/dom_path.js
@@ -1,0 +1,74 @@
+const DOM_PATH_SEGMENT_DELIMITER = '|';
+const DOM_PATH_STRING_PREFIX = 's:';
+const DOM_PATH_NUMBER_PREFIX = 'n:';
+const DOM_PATH_INTEGER_PATTERN = /^-?\d+$/;
+
+/**
+ * Serialize a document path for DOM data attributes.
+ *
+ * We include explicit type prefixes per segment, so decode stays lossless:
+ * - string segment => "s:<uri-encoded>"
+ * - number segment => "n:<integer>"
+ *
+ * @param {Array<string|number>} path
+ * @returns {string}
+ */
+export function serialize_dom_path(path) {
+	if (!Array.isArray(path)) {
+		throw new Error(`serialize_dom_path expected array, got ${typeof path}`);
+	}
+	return path
+		.map((segment) => {
+			if (typeof segment === 'number') {
+				if (!Number.isInteger(segment)) {
+					throw new Error(`serialize_dom_path expected integer segment, got ${segment}`);
+				}
+				return `${DOM_PATH_NUMBER_PREFIX}${segment}`;
+			}
+			if (typeof segment !== 'string') {
+				throw new Error(`serialize_dom_path expected string segment, got ${typeof segment}`);
+			}
+			return `${DOM_PATH_STRING_PREFIX}${encodeURIComponent(segment)}`;
+		})
+		.join(DOM_PATH_SEGMENT_DELIMITER);
+}
+
+/**
+ * Deserialize a DOM path key back to a document path.
+ *
+ * @param {string} path_key
+ * @param {{ allow_legacy_dot_path?: boolean }} [context]
+ * @returns {Array<string|number>}
+ */
+export function deserialize_dom_path(path_key, context = {}) {
+	if (typeof path_key !== 'string') {
+		throw new Error(`deserialize_dom_path expected string, got ${typeof path_key}`);
+	}
+	if (path_key.length === 0) return [];
+
+	const allow_legacy_dot_path = context.allow_legacy_dot_path ?? true;
+	const segments = path_key.split(DOM_PATH_SEGMENT_DELIMITER);
+	const decoded_segments = [];
+
+	for (const segment of segments) {
+		if (segment.startsWith(DOM_PATH_NUMBER_PREFIX)) {
+			const value = segment.slice(DOM_PATH_NUMBER_PREFIX.length);
+			if (!DOM_PATH_INTEGER_PATTERN.test(value)) {
+				throw new Error(`Invalid numeric DOM path segment "${segment}"`);
+			}
+			decoded_segments.push(parseInt(value, 10));
+			continue;
+		}
+		if (segment.startsWith(DOM_PATH_STRING_PREFIX)) {
+			const value = segment.slice(DOM_PATH_STRING_PREFIX.length);
+			decoded_segments.push(decodeURIComponent(value));
+			continue;
+		}
+		if (allow_legacy_dot_path) {
+			return path_key.split('.');
+		}
+		throw new Error(`Invalid DOM path segment "${segment}"`);
+	}
+
+	return decoded_segments;
+}

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -27,4 +27,5 @@ export { KeyMapper, define_keymap } from './KeyMapper.svelte.js';
 
 // Transforms and utilities
 export * from './transforms.svelte.js';
+export * from './dom_path.js';
 export * from './utils.js';

--- a/src/test/dom_path.test.js
+++ b/src/test/dom_path.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { serialize_dom_path, deserialize_dom_path } from '../lib/dom_path.js';
+
+describe('dom_path', () => {
+	it('round-trips mixed path segments losslessly', () => {
+		const path = ['page_1', 'body', 0, 'image_grid_items', 12, '123'];
+		const encoded = serialize_dom_path(path);
+		const decoded = deserialize_dom_path(encoded);
+		expect(decoded).toEqual(path);
+	});
+
+	it('preserves numeric-looking string IDs', () => {
+		const path = ['123', 'body', 0, 'items'];
+		const encoded = serialize_dom_path(path);
+		const decoded = deserialize_dom_path(encoded);
+		expect(decoded[0]).toBe('123');
+		expect(typeof decoded[0]).toBe('string');
+		expect(decoded[2]).toBe(0);
+		expect(typeof decoded[2]).toBe('number');
+	});
+
+	it('supports legacy dot paths when enabled', () => {
+		const decoded = deserialize_dom_path('page_1.body.0.items', { allow_legacy_dot_path: true });
+		expect(decoded).toEqual(['page_1', 'body', '0', 'items']);
+	});
+
+	it('rejects invalid encoded segments without legacy fallback', () => {
+		expect(() =>
+			deserialize_dom_path('page_1.body.0.items', { allow_legacy_dot_path: false })
+		).toThrow();
+	});
+});


### PR DESCRIPTION
## Summary
- add core helpers `serialize_dom_path(path)` and `deserialize_dom_path(path_key, context?)` in `src/lib/dom_path.js` to provide lossless, typed DOM path encoding
- migrate core `data-path` producers and consumers to use centralized helpers instead of ad-hoc `join('.')` / `split('.')`
- export the helpers via `src/lib/index.js` and add unit coverage in `src/test/dom_path.test.js` for roundtrip, numeric-string IDs, and legacy fallback behavior

## Test plan
- [ ] Run `npm run test:unit`
- [ ] In the demo, verify text, node, and property selections still map correctly after clicks/keyboard navigation
- [ ] In the demo, verify collapsed and expanded node selections still render and restore correctly


Made with [Cursor](https://cursor.com)