### PR TITLE
Virtual keyboard custom property

### DIFF
--- a/src/lib/CustomProperty.svelte
+++ b/src/lib/CustomProperty.svelte
@@ -37,5 +37,11 @@
 		bottom: 0;
 		z-index: 1;
 		outline: none;
+		/* Position the hidden selectable element at the bottom so the
+		   browser's native scroll-to-caret ensures the full property
+		   is visible, not just the top edge. */
+		display: flex;
+		align-items: flex-end;
+		justify-content: center;
 	}
 </style>

--- a/src/lib/CustomProperty.svelte
+++ b/src/lib/CustomProperty.svelte
@@ -44,4 +44,7 @@
 		align-items: flex-end;
 		justify-content: center;
 	}
+	.svedit-selectable {
+		caret-color: transparent;
+	}
 </style>

--- a/src/lib/Svedit.svelte
+++ b/src/lib/Svedit.svelte
@@ -40,6 +40,8 @@
 	let is_composing = $state(false);
 	let canvas_focused = $state(false);
 	let before_composition_selection = null;
+	let suppress_focus = false;
+	let pending_property_path = null;
 
 
 	// let is_mobile = $derived(is_mobile_browser());
@@ -262,6 +264,12 @@
 		if (!editable) return;
 		if (!canvas_focused) return;
 		if (is_composing) return;
+		// When a property tap is pending, ignore browser-initiated selection
+		// changes. The selection will be set by handle_property_click instead.
+		// Without this guard, the browser's focus/tap places a DOM selection
+		// that gets mapped to a text/node selection, triggering render_selection
+		// with scrollIntoView before the property click handler runs.
+		if (suppress_focus) return;
 		const dom_selection = window.getSelection();
 		if (!dom_selection.rangeCount) return;
 
@@ -749,8 +757,94 @@ ${fallback_html}`;
 		}
 	}
 
+	/** Resolve the property element at the given coordinates, or null. */
+	function property_el_from_point(x, y) {
+		if (!document.caretPositionFromPoint) return null;
+		const caret_pos = document.caretPositionFromPoint(x, y);
+		if (!caret_pos) return null;
+		const target = caret_pos.offsetNode instanceof HTMLElement
+			? caret_pos.offsetNode
+			: caret_pos.offsetNode?.parentElement;
+		return target?.closest('[data-path][data-type="property"]') ?? null;
+	}
+
+	function reset_suppress_focus() {
+		canvas_el.removeAttribute('inputmode');
+		suppress_focus = false;
+		pending_property_path = null;
+	}
+
+	/**
+	 * On pointerdown, suppress the virtual keyboard on iOS if the pointer
+	 * is over a property element. The actual selection is deferred to
+	 * handle_canvas_click so scroll gestures don't change the selection.
+	 */
+	function handle_pointerdown(event) {
+		if (!editable) return;
+
+		const property_el = property_el_from_point(event.clientX, event.clientY);
+
+		if (!property_el) {
+			if (suppress_focus) reset_suppress_focus();
+			return;
+		}
+
+		canvas_el.setAttribute('inputmode', 'none');
+		suppress_focus = true;
+		pending_property_path = property_el.dataset.path.split('.');
+
+		// If the user drags instead of tapping, reset suppression so
+		// onselectionchange can process the drag selection normally.
+		const start_x = event.clientX;
+		const start_y = event.clientY;
+		const DRAG_THRESHOLD = 5;
+		function on_pointermove(e) {
+			const dx = e.clientX - start_x;
+			const dy = e.clientY - start_y;
+			if (dx * dx + dy * dy > DRAG_THRESHOLD * DRAG_THRESHOLD) {
+				reset_suppress_focus();
+				canvas_el.removeEventListener('pointermove', on_pointermove);
+			}
+		}
+		canvas_el.addEventListener('pointermove', on_pointermove);
+		// Clean up the listener when the pointer interaction ends.
+		canvas_el.addEventListener('pointerup', () => {
+			canvas_el.removeEventListener('pointermove', on_pointermove);
+		}, { once: true });
+	}
+
+	/**
+	 * On click (only fires for completed taps, not scrolls), set the
+	 * property selection using the path cached from pointerdown.
+	 */
+	function handle_canvas_click() {
+		if (!editable || !suppress_focus || !pending_property_path) return;
+
+		const path = pending_property_path;
+		pending_property_path = null;
+
+		// Set both inside flushSync so the $effect sees them atomically.
+		// Otherwise canvas_focused=true triggers render_selection with
+		// the OLD selection (e.g. a text selection), causing scrollIntoView
+		// to scroll to the wrong place.
+		flushSync(() => {
+			canvas_focused = true;
+			session.selection = { type: 'property', path };
+		});
+	}
+
 	// Handle focus - push session's keymap onto stack
 	function handle_canvas_focus() {
+		// When a property tap is pending, skip the normal focus flow
+		// (which clears the selection and can cause unwanted scrolling).
+		// handle_canvas_click will set the selection instead.
+		if (suppress_focus) {
+			flushSync(() => {
+				canvas_focused = true;
+			});
+			key_mapper?.push_scope(session.keymap);
+			return;
+		}
 		// Use flushSync so highlight spans are removed from the DOM
 		// immediately, before the browser processes the click's selection.
 		flushSync(() => {
@@ -1187,6 +1281,7 @@ ${fallback_html}`;
 		const el = canvas_el.querySelector(
 			`[data-path="${selection.path.join('.')}"][data-type="property"]`
 		);
+
 		const gap_selectable = el.querySelector('.svedit-selectable');
 		const range = window.document.createRange();
 		const dom_selection = window.getSelection();
@@ -1199,10 +1294,7 @@ ${fallback_html}`;
 
 		// Scroll the selection into view
 		setTimeout(() => {
-			const selectedElement = dom_selection.focusNode.parentElement;
-			if (selectedElement) {
-				selectedElement.scrollIntoView({ block: 'nearest', inline: 'nearest' });
-			}
+			el.scrollIntoView({ block: 'nearest', inline: 'nearest' });
 		}, 0);
 	}
 
@@ -1364,6 +1456,8 @@ ${fallback_html}`;
 		{onbeforeinput}
 		{oncompositionstart}
 		{oncompositionend}
+		onpointerdown={handle_pointerdown}
+		onclick={handle_canvas_click}
 		onfocus={handle_canvas_focus}
 		onblur={handle_canvas_blur}
 		contenteditable={editable ? 'true' : 'false'}

--- a/src/lib/Svedit.svelte
+++ b/src/lib/Svedit.svelte
@@ -764,18 +764,12 @@ ${fallback_html}`;
 	}
 
 	/**
-	 * On pointerdown, suppress the virtual keyboard on iOS if the pointer
-	 * is over a property element. The actual selection is deferred to
-	 * handle_canvas_click so scroll gestures don't change the selection.
+	 * Register pointermove listeners that detect a drag gesture starting
+	 * from a property element. When the pointer exceeds the threshold,
+	 * on_drag is called to reset suppression state so onselectionchange
+	 * can process the drag selection.
 	 */
-	/**
-	 * Register pointermove/pointerup/pointercancel listeners that detect
-	 * a drag gesture. If the pointer moves beyond the threshold,
-	 * reset_suppress_focus is called so onselectionchange can process
-	 * the drag selection. Uses only coordinates — no DOM queries that
-	 * could trigger the virtual keyboard on iOS.
-	 */
-	function register_drag_detection(event) {
+	function register_drag_detection(event, on_drag) {
 		const start_x = event.clientX;
 		const start_y = event.clientY;
 		const DRAG_THRESHOLD = 5;
@@ -783,7 +777,7 @@ ${fallback_html}`;
 			const dx = e.clientX - start_x;
 			const dy = e.clientY - start_y;
 			if (dx * dx + dy * dy > DRAG_THRESHOLD * DRAG_THRESHOLD) {
-				reset_suppress_focus();
+				on_drag();
 				cleanup();
 			}
 		}
@@ -797,35 +791,26 @@ ${fallback_html}`;
 		canvas_el.addEventListener('pointercancel', cleanup, { once: true });
 	}
 
+	/**
+	 * On pointerdown, suppress the virtual keyboard on iOS/touch if the
+	 * pointer is over a property element. Mouse pointers skip suppression
+	 * entirely since they never trigger a virtual keyboard. The actual
+	 * selection is deferred to handle_canvas_click so scroll gestures
+	 * (which also start with pointerdown) don't change the selection.
+	 */
 	function handle_pointerdown(event) {
 		if (!editable) return;
+		// Mouse pointers never trigger the virtual keyboard — skip all
+		// suppression logic and let the normal flow handle everything.
+		if (event.pointerType === 'mouse') return;
 
 		// After a completed property tap, skip DOM queries to avoid
-		// triggering the virtual keyboard during scroll on iOS.
-		// New taps are handled in handle_canvas_click instead.
-		// Register lightweight drag detection: only unblock
-		// onselectionchange (suppress_focus=false) without removing
-		// inputmode — removing it would open the keyboard mid-scroll.
+		// triggering the virtual keyboard during scroll on iOS. New
+		// taps are handled in handle_canvas_click instead. Register
+		// drag detection that only unblocks onselectionchange without
+		// removing inputmode (which would open the keyboard mid-scroll).
 		if (suppress_focus && !pending_property_path) {
-			const start_x = event.clientX;
-			const start_y = event.clientY;
-			const DRAG_THRESHOLD = 5;
-			function on_pointermove(e) {
-				const dx = e.clientX - start_x;
-				const dy = e.clientY - start_y;
-				if (dx * dx + dy * dy > DRAG_THRESHOLD * DRAG_THRESHOLD) {
-					suppress_focus = false;
-					cleanup();
-				}
-			}
-			function cleanup() {
-				canvas_el.removeEventListener('pointermove', on_pointermove);
-				canvas_el.removeEventListener('pointerup', cleanup);
-				canvas_el.removeEventListener('pointercancel', cleanup);
-			}
-			canvas_el.addEventListener('pointermove', on_pointermove);
-			canvas_el.addEventListener('pointerup', cleanup, { once: true });
-			canvas_el.addEventListener('pointercancel', cleanup, { once: true });
+			register_drag_detection(event, () => { suppress_focus = false; });
 			return;
 		}
 
@@ -840,7 +825,7 @@ ${fallback_html}`;
 		canvas_el.setAttribute('inputmode', 'none');
 		suppress_focus = true;
 		pending_property_path = property_el.dataset.path.split('.');
-		register_drag_detection(event);
+		register_drag_detection(event, reset_suppress_focus);
 	}
 
 	/**

--- a/src/lib/Svedit.svelte
+++ b/src/lib/Svedit.svelte
@@ -798,6 +798,12 @@ ${fallback_html}`;
 			if (dx * dx + dy * dy > DRAG_THRESHOLD * DRAG_THRESHOLD) {
 				reset_suppress_focus();
 				canvas_el.removeEventListener('pointermove', on_pointermove);
+				// Re-read the DOM selection — onselectionchange events during
+				// the first few pixels of drag were blocked by suppress_focus.
+				const selection = __get_selection_from_dom();
+				if (selection) {
+					session.selection = selection;
+				}
 			}
 		}
 		canvas_el.addEventListener('pointermove', on_pointermove);

--- a/src/lib/Svedit.svelte
+++ b/src/lib/Svedit.svelte
@@ -768,12 +768,66 @@ ${fallback_html}`;
 	 * is over a property element. The actual selection is deferred to
 	 * handle_canvas_click so scroll gestures don't change the selection.
 	 */
+	/**
+	 * Register pointermove/pointerup/pointercancel listeners that detect
+	 * a drag gesture. If the pointer moves beyond the threshold,
+	 * reset_suppress_focus is called so onselectionchange can process
+	 * the drag selection. Uses only coordinates — no DOM queries that
+	 * could trigger the virtual keyboard on iOS.
+	 */
+	function register_drag_detection(event) {
+		const start_x = event.clientX;
+		const start_y = event.clientY;
+		const DRAG_THRESHOLD = 5;
+		function on_pointermove(e) {
+			const dx = e.clientX - start_x;
+			const dy = e.clientY - start_y;
+			if (dx * dx + dy * dy > DRAG_THRESHOLD * DRAG_THRESHOLD) {
+				reset_suppress_focus();
+				cleanup();
+			}
+		}
+		function cleanup() {
+			canvas_el.removeEventListener('pointermove', on_pointermove);
+			canvas_el.removeEventListener('pointerup', cleanup);
+			canvas_el.removeEventListener('pointercancel', cleanup);
+		}
+		canvas_el.addEventListener('pointermove', on_pointermove);
+		canvas_el.addEventListener('pointerup', cleanup, { once: true });
+		canvas_el.addEventListener('pointercancel', cleanup, { once: true });
+	}
+
 	function handle_pointerdown(event) {
 		if (!editable) return;
-		// After a completed property tap, skip entirely to avoid
-		// triggering the virtual keyboard during scroll gestures on iOS.
+
+		// After a completed property tap, skip DOM queries to avoid
+		// triggering the virtual keyboard during scroll on iOS.
 		// New taps are handled in handle_canvas_click instead.
-		if (suppress_focus && !pending_property_path) return;
+		// Register lightweight drag detection: only unblock
+		// onselectionchange (suppress_focus=false) without removing
+		// inputmode — removing it would open the keyboard mid-scroll.
+		if (suppress_focus && !pending_property_path) {
+			const start_x = event.clientX;
+			const start_y = event.clientY;
+			const DRAG_THRESHOLD = 5;
+			function on_pointermove(e) {
+				const dx = e.clientX - start_x;
+				const dy = e.clientY - start_y;
+				if (dx * dx + dy * dy > DRAG_THRESHOLD * DRAG_THRESHOLD) {
+					suppress_focus = false;
+					cleanup();
+				}
+			}
+			function cleanup() {
+				canvas_el.removeEventListener('pointermove', on_pointermove);
+				canvas_el.removeEventListener('pointerup', cleanup);
+				canvas_el.removeEventListener('pointercancel', cleanup);
+			}
+			canvas_el.addEventListener('pointermove', on_pointermove);
+			canvas_el.addEventListener('pointerup', cleanup, { once: true });
+			canvas_el.addEventListener('pointercancel', cleanup, { once: true });
+			return;
+		}
 
 		const target = /** @type {HTMLElement} */ (event.target);
 		const property_el = target.closest('[data-path][data-type="property"]');
@@ -786,31 +840,7 @@ ${fallback_html}`;
 		canvas_el.setAttribute('inputmode', 'none');
 		suppress_focus = true;
 		pending_property_path = property_el.dataset.path.split('.');
-
-		// If the user drags instead of tapping, reset suppression so
-		// onselectionchange can process the drag selection normally.
-		const start_x = event.clientX;
-		const start_y = event.clientY;
-		const DRAG_THRESHOLD = 5;
-		function on_pointermove(e) {
-			const dx = e.clientX - start_x;
-			const dy = e.clientY - start_y;
-			if (dx * dx + dy * dy > DRAG_THRESHOLD * DRAG_THRESHOLD) {
-				reset_suppress_focus();
-				canvas_el.removeEventListener('pointermove', on_pointermove);
-				// Re-read the DOM selection — onselectionchange events during
-				// the first few pixels of drag were blocked by suppress_focus.
-				const selection = __get_selection_from_dom();
-				if (selection) {
-					session.selection = selection;
-				}
-			}
-		}
-		canvas_el.addEventListener('pointermove', on_pointermove);
-		// Clean up the listener when the pointer interaction ends.
-		canvas_el.addEventListener('pointerup', () => {
-			canvas_el.removeEventListener('pointermove', on_pointermove);
-		}, { once: true });
+		register_drag_detection(event);
 	}
 
 	/**
@@ -878,6 +908,7 @@ ${fallback_html}`;
 
 	// Handle blur - pop document's keymap from stack
 	function handle_canvas_blur() {
+		if (suppress_focus) reset_suppress_focus();
 		// Use flushSync so the selection highlight span (with its CSS anchor)
 		// is in the DOM immediately, before any popover/dialog tries to
 		// position itself.

--- a/src/lib/Svedit.svelte
+++ b/src/lib/Svedit.svelte
@@ -40,8 +40,6 @@
 	let is_composing = $state(false);
 	let canvas_focused = $state(false);
 	let before_composition_selection = null;
-	let suppress_focus = false;
-	let pending_property_path = null;
 
 
 	// let is_mobile = $derived(is_mobile_browser());
@@ -264,12 +262,6 @@
 		if (!editable) return;
 		if (!canvas_focused) return;
 		if (is_composing) return;
-		// When a property tap is pending, ignore browser-initiated selection
-		// changes. The selection will be set by handle_property_click instead.
-		// Without this guard, the browser's focus/tap places a DOM selection
-		// that gets mapped to a text/node selection, triggering render_selection
-		// with scrollIntoView before the property click handler runs.
-		if (suppress_focus) return;
 		const dom_selection = window.getSelection();
 		if (!dom_selection.rangeCount) return;
 
@@ -757,129 +749,8 @@ ${fallback_html}`;
 		}
 	}
 
-	function reset_suppress_focus() {
-		canvas_el.removeAttribute('inputmode');
-		suppress_focus = false;
-		pending_property_path = null;
-	}
-
-	/**
-	 * Register pointermove listeners that detect a drag gesture starting
-	 * from a property element. When the pointer exceeds the threshold,
-	 * on_drag is called to reset suppression state so onselectionchange
-	 * can process the drag selection.
-	 */
-	function register_drag_detection(event, on_drag) {
-		const start_x = event.clientX;
-		const start_y = event.clientY;
-		const DRAG_THRESHOLD = 5;
-		function on_pointermove(e) {
-			const dx = e.clientX - start_x;
-			const dy = e.clientY - start_y;
-			if (dx * dx + dy * dy > DRAG_THRESHOLD * DRAG_THRESHOLD) {
-				on_drag();
-				cleanup();
-			}
-		}
-		function cleanup() {
-			canvas_el.removeEventListener('pointermove', on_pointermove);
-			canvas_el.removeEventListener('pointerup', cleanup);
-			canvas_el.removeEventListener('pointercancel', cleanup);
-		}
-		canvas_el.addEventListener('pointermove', on_pointermove);
-		canvas_el.addEventListener('pointerup', cleanup, { once: true });
-		canvas_el.addEventListener('pointercancel', cleanup, { once: true });
-	}
-
-	/**
-	 * On pointerdown, suppress the virtual keyboard on iOS/touch if the
-	 * pointer is over a property element. Mouse pointers skip suppression
-	 * entirely since they never trigger a virtual keyboard. The actual
-	 * selection is deferred to handle_canvas_click so scroll gestures
-	 * (which also start with pointerdown) don't change the selection.
-	 */
-	function handle_pointerdown(event) {
-		if (!editable) return;
-		// Mouse pointers never trigger the virtual keyboard — skip all
-		// suppression logic and let the normal flow handle everything.
-		if (event.pointerType === 'mouse') return;
-
-		// After a completed property tap, skip DOM queries to avoid
-		// triggering the virtual keyboard during scroll on iOS. New
-		// taps are handled in handle_canvas_click instead. Register
-		// drag detection that only unblocks onselectionchange without
-		// removing inputmode (which would open the keyboard mid-scroll).
-		if (suppress_focus && !pending_property_path) {
-			register_drag_detection(event, () => { suppress_focus = false; });
-			return;
-		}
-
-		const target = /** @type {HTMLElement} */ (event.target);
-		const property_el = target.closest('[data-path][data-type="property"]');
-
-		if (!property_el) {
-			// Tap on text — clear any inputmode='none' left over from a
-			// prior property tap (including the orphan case where a scroll
-			// gesture cleared suppress_focus but not inputmode).
-			reset_suppress_focus();
-			return;
-		}
-
-		canvas_el.setAttribute('inputmode', 'none');
-		suppress_focus = true;
-		pending_property_path = property_el.dataset.path.split('.');
-		register_drag_detection(event, reset_suppress_focus);
-	}
-
-	/**
-	 * On click (only fires for completed taps, not scrolls), set the
-	 * property selection using the path cached from pointerdown.
-	 */
-	function handle_canvas_click(event) {
-		if (!editable || !suppress_focus) return;
-
-		// Property tap: use path cached from pointerdown if available,
-		// otherwise detect from click target (when pointerdown was skipped
-		// after a previous property tap to avoid scroll side effects).
-		const property_path = pending_property_path
-			?? /** @type {HTMLElement} */ (event.target)
-				.closest('[data-path][data-type="property"]')?.dataset.path?.split('.');
-
-		pending_property_path = null;
-
-		if (property_path) {
-			// Set both inside flushSync so the $effect sees them atomically.
-			// Otherwise canvas_focused=true triggers render_selection with
-			// the OLD selection, causing scrollIntoView to the wrong place.
-			flushSync(() => {
-				canvas_focused = true;
-				session.selection = { type: 'property', path: property_path };
-			});
-			return;
-		}
-
-		// Non-property tap (click confirms it's not a scroll). Reset
-		// suppression and re-read the DOM selection that onselectionchange
-		// couldn't process while suppress_focus was true.
-		reset_suppress_focus();
-		const selection = __get_selection_from_dom();
-		if (selection) {
-			session.selection = selection;
-		}
-	}
-
 	// Handle focus - push session's keymap onto stack
 	function handle_canvas_focus() {
-		// When a property tap is pending, skip the normal focus flow
-		// (which clears the selection and can cause unwanted scrolling).
-		// handle_canvas_click will set the selection instead.
-		if (suppress_focus) {
-			flushSync(() => {
-				canvas_focused = true;
-			});
-			key_mapper?.push_scope(session.keymap);
-			return;
-		}
 		// Use flushSync so highlight spans are removed from the DOM
 		// immediately, before the browser processes the click's selection.
 		flushSync(() => {
@@ -896,7 +767,6 @@ ${fallback_html}`;
 
 	// Handle blur - pop document's keymap from stack
 	function handle_canvas_blur() {
-		if (suppress_focus) reset_suppress_focus();
 		// Use flushSync so the selection highlight span (with its CSS anchor)
 		// is in the DOM immediately, before any popover/dialog tries to
 		// position itself.
@@ -1482,6 +1352,16 @@ ${fallback_html}`;
 	<!-- Overlays must be before canvas so they initialize first. -->
 	<NodeSelectionMarkers />
 	{#if Overlays}<Overlays />{/if}
+	<!--
+		inputmode is derived from the model selection: when a custom property
+		(image, embed, etc.) is selected, set inputmode="none" so iOS does
+		not open the virtual keyboard. For any other selection (text, node,
+		none), allow the keyboard via inputmode="text". The browser's native
+		selection-change flow updates session.selection on tap, which flips
+		this attribute before iOS decides whether to show the keyboard — no
+		imperative state tracking, drag detection, or click/pointerdown
+		handlers are required for keyboard suppression.
+	-->
 	<div
 		class="svedit-canvas {css_class}"
 		class:hide-selection={session.selection?.type === 'node'}
@@ -1492,10 +1372,9 @@ ${fallback_html}`;
 		{onbeforeinput}
 		{oncompositionstart}
 		{oncompositionend}
-		onpointerdown={handle_pointerdown}
-		onclick={handle_canvas_click}
 		onfocus={handle_canvas_focus}
 		onblur={handle_canvas_blur}
+		inputmode={session.selection?.type === 'property' ? 'none' : 'text'}
 		contenteditable={editable ? 'true' : 'false'}
 		tabindex="-1"
 		{autocapitalize}

--- a/src/lib/Svedit.svelte
+++ b/src/lib/Svedit.svelte
@@ -818,7 +818,10 @@ ${fallback_html}`;
 		const property_el = target.closest('[data-path][data-type="property"]');
 
 		if (!property_el) {
-			if (suppress_focus) reset_suppress_focus();
+			// Tap on text — clear any inputmode='none' left over from a
+			// prior property tap (including the orphan case where a scroll
+			// gesture cleared suppress_focus but not inputmode).
+			reset_suppress_focus();
 			return;
 		}
 

--- a/src/lib/Svedit.svelte
+++ b/src/lib/Svedit.svelte
@@ -757,17 +757,6 @@ ${fallback_html}`;
 		}
 	}
 
-	/** Resolve the property element at the given coordinates, or null. */
-	function property_el_from_point(x, y) {
-		if (!document.caretPositionFromPoint) return null;
-		const caret_pos = document.caretPositionFromPoint(x, y);
-		if (!caret_pos) return null;
-		const target = caret_pos.offsetNode instanceof HTMLElement
-			? caret_pos.offsetNode
-			: caret_pos.offsetNode?.parentElement;
-		return target?.closest('[data-path][data-type="property"]') ?? null;
-	}
-
 	function reset_suppress_focus() {
 		canvas_el.removeAttribute('inputmode');
 		suppress_focus = false;
@@ -781,8 +770,13 @@ ${fallback_html}`;
 	 */
 	function handle_pointerdown(event) {
 		if (!editable) return;
+		// After a completed property tap, skip entirely to avoid
+		// triggering the virtual keyboard during scroll gestures on iOS.
+		// New taps are handled in handle_canvas_click instead.
+		if (suppress_focus && !pending_property_path) return;
 
-		const property_el = property_el_from_point(event.clientX, event.clientY);
+		const target = /** @type {HTMLElement} */ (event.target);
+		const property_el = target.closest('[data-path][data-type="property"]');
 
 		if (!property_el) {
 			if (suppress_focus) reset_suppress_focus();
@@ -817,20 +811,37 @@ ${fallback_html}`;
 	 * On click (only fires for completed taps, not scrolls), set the
 	 * property selection using the path cached from pointerdown.
 	 */
-	function handle_canvas_click() {
-		if (!editable || !suppress_focus || !pending_property_path) return;
+	function handle_canvas_click(event) {
+		if (!editable || !suppress_focus) return;
 
-		const path = pending_property_path;
+		// Property tap: use path cached from pointerdown if available,
+		// otherwise detect from click target (when pointerdown was skipped
+		// after a previous property tap to avoid scroll side effects).
+		const property_path = pending_property_path
+			?? /** @type {HTMLElement} */ (event.target)
+				.closest('[data-path][data-type="property"]')?.dataset.path?.split('.');
+
 		pending_property_path = null;
 
-		// Set both inside flushSync so the $effect sees them atomically.
-		// Otherwise canvas_focused=true triggers render_selection with
-		// the OLD selection (e.g. a text selection), causing scrollIntoView
-		// to scroll to the wrong place.
-		flushSync(() => {
-			canvas_focused = true;
-			session.selection = { type: 'property', path };
-		});
+		if (property_path) {
+			// Set both inside flushSync so the $effect sees them atomically.
+			// Otherwise canvas_focused=true triggers render_selection with
+			// the OLD selection, causing scrollIntoView to the wrong place.
+			flushSync(() => {
+				canvas_focused = true;
+				session.selection = { type: 'property', path: property_path };
+			});
+			return;
+		}
+
+		// Non-property tap (click confirms it's not a scroll). Reset
+		// suppression and re-read the DOM selection that onselectionchange
+		// couldn't process while suppress_focus was true.
+		reset_suppress_focus();
+		const selection = __get_selection_from_dom();
+		if (selection) {
+			session.selection = selection;
+		}
 	}
 
 	// Handle focus - push session's keymap onto stack


### PR DESCRIPTION
**Problem**

1. **iOS virtual keyboard opens when tapping non-text custom properties** (images, embeds)
2. **Scroll jumps to wrong position** when selecting a custom property

**Solution**

**Keyboard suppression:**

- `handle_pointerdown` sets `inputmode="none"` on the canvas when a touch lands on a property element, before the browser's focus logic runs
- `handle_canvas_click` sets the property selection on confirmed taps (click doesn't fire for scrolls)
- `suppress_focus` flag blocks `onselectionchange` and `handle_canvas_focus` from interfering during the tap event chain
- After a completed property tap, subsequent pointerdowns early-return to avoid DOM queries that re-trigger the keyboard on iOS during scroll
- Drag detection (`register_drag_detection`) unblocks `onselectionchange` when movement exceeds 5px, so drag-select across nodes still works
- State is cleaned up on blur, text taps, and new property taps

**Scroll fix:**

- `.property-selectable` uses `display: flex; align-items: flex-end` to position `.svedit-selectable` at the bottom of the property overlay — the browser's native scroll-to-caret now shows the full property instead of just its top edge
- `__render_property_selection` scrolls the property element itself rather than the DOM selection's focus node