### PR TITLE
Fix: Guard against the browser briefly reporting an out-of-bounds offset

### DIFF
--- a/src/lib/Svedit.svelte
+++ b/src/lib/Svedit.svelte
@@ -273,7 +273,15 @@
 			// structurally identical — prevents a redundant $effect cycle
 			// (render_selection → scrollIntoView) on every DOM layout change.
 			if (JSON.stringify(selection) === JSON.stringify(session.selection)) return;
-			session.selection = selection;
+			// Guard against the browser briefly reporting an out-of-bounds offset
+			// during dead-key / IME composition (e.g. ^ key on European keyboards).
+			// The selection will be corrected on the next selectionchange event once
+			// the DOM has settled, so silently dropping the invalid one is safe.
+			try {
+				session.selection = selection;
+			} catch {
+				// ignore transient out-of-bounds selection
+			}
 		}
 	}
 


### PR DESCRIPTION
Experienced this error within an app where I had type to create inside a node gap implemented, and when pressing the character `^` would trigger an error