### PR TITLE
Cycle z-index on-overlapping node-gaps

### DIFF
--- a/src/lib/NodeGap.svelte
+++ b/src/lib/NodeGap.svelte
@@ -1,3 +1,15 @@
+<script module>
+	function cycle_z_index(/** @type {MouseEvent} */ e) {
+		const el = /** @type {HTMLElement} */ (e.currentTarget);
+		if (el.hasAttribute('data-sent-to-back')) {
+			document.querySelectorAll('.svedit-selectable[data-sent-to-back]').forEach(prev => {
+				prev.removeAttribute('data-sent-to-back');
+			});
+		}
+		el.setAttribute('data-sent-to-back', '');
+	}
+</script>
+
 <script>
 	import { serialize_path } from './utils.js';
 	import { getContext } from 'svelte';
@@ -78,7 +90,8 @@
 		data-gap-offset={offset}
 		style={gap_style}
 	>
-		<div class="svedit-selectable" style="anchor-name:{anchor_name}"><br /></div>
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
+		<div class="svedit-selectable" style="anchor-name:{anchor_name}" onpointerdown={cycle_z_index}><br /></div>
 	</div>
 {:else}
 	<div class="node-gap"></div>
@@ -178,6 +191,10 @@
 		position-visibility: anchors-visible;
 		z-index: var(--node-caret-gap-z-index, 1);
 		cursor: pointer;
+	}
+
+	.positioned :global(.svedit-selectable[data-sent-to-back]) {
+		z-index: 0;
 	}
 
 	/* ------------------------------------------------------------------ */

--- a/src/lib/NodeGap.svelte
+++ b/src/lib/NodeGap.svelte
@@ -1,3 +1,15 @@
+<script module>
+	function cycle_z_index(/** @type {MouseEvent} */ e) {
+		const el = /** @type {HTMLElement} */ (e.currentTarget);
+		if (el.hasAttribute('data-sent-to-back')) {
+			document.querySelectorAll('.svedit-selectable[data-sent-to-back]').forEach(prev => {
+				prev.removeAttribute('data-sent-to-back');
+			});
+		}
+		el.setAttribute('data-sent-to-back', '');
+	}
+</script>
+
 <script>
 	import { getContext } from 'svelte';
 
@@ -77,7 +89,8 @@
 		data-gap-offset={offset}
 		style={gap_style}
 	>
-		<div class="svedit-selectable" style="anchor-name:{anchor_name}"><br /></div>
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
+		<div class="svedit-selectable" style="anchor-name:{anchor_name}" onpointerdown={cycle_z_index}><br /></div>
 	</div>
 {:else}
 	<div class="node-gap"></div>
@@ -178,6 +191,10 @@
 		position-visibility: anchors-visible;
 		z-index: var(--node-caret-gap-z-index, 1);
 		cursor: pointer;
+	}
+
+	.positioned :global(.svedit-selectable[data-sent-to-back]) {
+		z-index: 0;
 	}
 
 	/* ------------------------------------------------------------------ */


### PR DESCRIPTION
Issue:
e.g. for nested node arrays within other node arrays with no padding/ margin, the node-gaps can overlap. To still allow clicks on the parent or child we can cycle through them on each click.

this change uses a stateless cycle_z_index function that queries the DOM for the previous [data-sent-to-back] element, removes the attribute, then sets it on the clicked element.

A CSS rule `.positioned :global(.svedit-selectable[data-sent-to-back])` lowers z-index to 0, keeping it above regular content but below sibling gaps at z-index: 1, enabling the change on the next click