### PR TITLE
AnnotatedTextProperty: text-box: trim; where() clauses; caret alignment fix

### DIFF
--- a/src/lib/AnnotatedTextProperty.svelte
+++ b/src/lib/AnnotatedTextProperty.svelte
@@ -162,8 +162,8 @@
 
 	/* Fix Chrome bug: caret correct on baseline in empty contenteditable. */
 	:where(.text.editable.empty) {
-		line-height: 1cap;
-		min-height: 1cap;
+		line-height: 1cap !important;
+		min-height: 1cap !important;
 	}
 
 	/* We switch from ::before to ::after when the element is focused. So the the caret is always before the placeholder. */

--- a/src/lib/AnnotatedTextProperty.svelte
+++ b/src/lib/AnnotatedTextProperty.svelte
@@ -146,11 +146,26 @@
 </svelte:element>
 
 <style>
-	.text {
+	/* Editable text base layout; :where() allows easy override without specificity conflicts. */
+	:where(.text) {
 		white-space: pre-wrap;
 		overflow-wrap: anywhere;
 		box-sizing: content-box;
 	}
+
+	/* Trim extra vertical space for precise padding; keeps descenders visible. Considered a new baseline for typography on the web. */
+	@supports (text-box: trim-both cap text) {
+		:where(.text) {
+			text-box: trim-both cap text;
+		}
+	}
+
+	/* Fix Chrome bug: caret correct on baseline in empty contenteditable. */
+	:where(.text.editable.empty) {
+		line-height: 1cap;
+		min-height: 1cap;
+	}
+
 	/* We switch from ::before to ::after when the element is focused. So the the caret is always before the placeholder. */
 	[placeholder].empty:not(.focused)::before,
 	[placeholder].empty.focused::after {

--- a/src/lib/AnnotatedTextProperty.svelte
+++ b/src/lib/AnnotatedTextProperty.svelte
@@ -160,12 +160,6 @@
 		}
 	}
 
-	/* Fix Chrome bug: caret correct on baseline in empty contenteditable. */
-	:where(.text.editable.empty) {
-		line-height: 1cap !important;
-		min-height: 1cap !important;
-	}
-
 	/* We switch from ::before to ::after when the element is focused. So the the caret is always before the placeholder. */
 	[placeholder].empty:not(.focused)::before,
 	[placeholder].empty.focused::after {

--- a/src/lib/AnnotatedTextProperty.svelte
+++ b/src/lib/AnnotatedTextProperty.svelte
@@ -153,10 +153,10 @@
 		box-sizing: content-box;
 	}
 
-	/* Trim extra vertical space for precise padding; keeps descenders visible. Considered a new baseline for typography on the web. */
-	@supports (text-box: trim-both cap text) {
+	/* Trim extra vertical space for precise padding; Considered a new baseline for typography on the web. */
+	@supports (text-box: trim-both cap alphabetic) {
 		:where(.text) {
-			text-box: trim-both cap text;
+			text-box: trim-both cap alphabetic;
 		}
 	}
 


### PR DESCRIPTION
- reduce specificity of classes, so no conflicts with :global() rules.
- make trim-both cap text the default for texts on the web. 
- fix bug in chrome with misaligned caret in empty contenteditable when text-box is used