### PR TITLE
Serialize/deserialize document paths reliably

### DIFF
--- a/src/lib/AnnotatedTextProperty.svelte
+++ b/src/lib/AnnotatedTextProperty.svelte
@@ -1,6 +1,13 @@
 <script>
 	import { getContext } from 'svelte';
-	import { char_slice, get_char_length, snake_to_pascal, get_selection_range } from './utils.js';
+	import {
+		char_slice,
+		get_char_length,
+		paths_equal,
+		serialize_path,
+		snake_to_pascal,
+		get_selection_range
+	} from './utils.js';
 
 	/** @import { AnnotatedTextPropertyProps, Annotation, Fragment, SelectionRange } from './types.d.ts'; */
 
@@ -9,12 +16,11 @@
 	/** @type {AnnotatedTextPropertyProps} */
 	let { path, class: css_class, placeholder = '', tag = 'div', style = '', ...rest } = $props();
 
-	let path_str = $derived(path.join('.'));
+	let path_str = $derived(serialize_path(path));
 
 	let is_focused = $derived.by(() => {
 		return (
-			svedit.session.selection?.type === 'text' &&
-			path_str === svedit.session.selection?.path.join('.')
+			svedit.session.selection?.type === 'text' && paths_equal(path, svedit.session.selection.path)
 		);
 	});
 
@@ -120,8 +126,8 @@
 <svelte:element
 	this={tag}
 	data-type="text"
-	data-path={path.join('.')}
-	style="anchor-name: --{path.join('-')};{style}"
+	data-path={path_str}
+	style="anchor-name: --{path_str};{style}"
 	class="text svedit-selectable {css_class}"
 	class:empty={is_empty}
 	class:focused={is_focused}

--- a/src/lib/CustomProperty.svelte
+++ b/src/lib/CustomProperty.svelte
@@ -1,12 +1,13 @@
 <script>
 	import { getContext } from 'svelte';
+	import { serialize_path } from './utils.js';
 
 	/** @import { CustomPropertyProps } from './types.d.ts'; */
 	const svedit = getContext('svedit');
 
 	/** @type {CustomPropertyProps} */
 	let { path, tag = 'div', class: css_class, children, style, ...rest } = $props();
-	let path_str = $derived(path.join('.'));
+	let path_str = $derived(serialize_path(path));
 
 	// Enforce the "one path = one DOM mount per document" invariant
 	$effect(() => {
@@ -21,7 +22,7 @@
 	class={css_class}
 	data-type="property"
 	data-path={path_str}
-	style="anchor-name: --{path.join('-')};{style ? ` ${style}` : ''}"
+	style="anchor-name: --{path_str};{style ? ` ${style}` : ''}"
 	{...rest}
 >
 	{#if svedit.editable}

--- a/src/lib/Node.svelte
+++ b/src/lib/Node.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { getContext } from 'svelte';
+	import { serialize_path } from './utils.js';
 
 	/** @import { NodeProps } from './types.d.ts'; */
 
@@ -9,6 +10,7 @@
 	let { path, children, tag = 'div', class: css_class, style = '', ...rest } = $props();
 
 	let node = $derived(svedit.session.get(path));
+	let path_str = $derived(serialize_path(path));
 
 	const node_array_meta = getContext('node_array_meta');
 	let child_index = $derived(node_array_meta ? parseInt(String(path.at(-1)), 10) : -1);
@@ -17,13 +19,13 @@
 </script>
 
 <svelte:element
-	id={node.id}
 	this={tag}
+	id={node.id}
 	class="node-{node.type} {css_class}{is_first ? ' first' : ''}{is_last ? ' last' : ''}"
 	data-node-id={node.id}
-	data-path={path.join('.')}
+	data-path={path_str}
 	data-type="node"
-	style="anchor-name: --{path.join('-')};{style}"
+	style="anchor-name: --{path_str};{style}"
 	{...rest}
 >
 	{@render children()}

--- a/src/lib/NodeArrayProperty.svelte
+++ b/src/lib/NodeArrayProperty.svelte
@@ -1,7 +1,7 @@
 <script>
 	import { getContext, setContext } from 'svelte';
 	import UnknownNode from './UnknownNode.svelte';
-	import { snake_to_pascal } from './utils.js';
+	import { serialize_path, snake_to_pascal } from './utils.js';
 	import DefaultNodeGap from './NodeGap.svelte';
 	import DefaultNodeGapMarkers from './NodeGapMarkers.svelte';
 
@@ -16,10 +16,10 @@
 
 	// Pre-joined once per path change; reused by data-path and by every
 	// NodeGap's should_position_gap call to avoid N+1 joins per render.
-	let path_str = $derived(path.join('.'));
+	let path_str = $derived(serialize_path(path));
 
 	let node_ids = $derived(svedit.session.get(path));
-	let nodes = $derived(node_ids.map(id => svedit.session.get(id)));
+	let nodes = $derived(node_ids.map((id) => svedit.session.get(id)));
 
 	// Mirrors the AnnotatedTextProperty pattern: a `focused` class follows
 	// the model selection. Used by the CSS rule below to hide the empty-array
@@ -27,11 +27,13 @@
 	// second arrow-key stop (issue #260).
 	let is_focused = $derived(
 		svedit.session.selection?.type === 'node'
-		&& svedit.session.selection.path.join('.') === path_str
+		&& serialize_path(svedit.session.selection.path) === path_str
 	);
 
 	setContext('node_array_meta', {
-		get length() { return node_ids.length; }
+		get length() {
+			return node_ids.length;
+		}
 	});
 
 	// Enforce the "one path = one DOM mount per document" invariant
@@ -40,8 +42,8 @@
 		svedit.session.register_mount(current_path_str);
 		return () => svedit.session.unregister_mount(current_path_str);
 	});
-
 </script>
+
 <!-- we use the anchor of node_array in Overlays.svelte to position the last insertion point in a horizontal layout based on the right edge of the container -->
 <svelte:element
 	this={tag}
@@ -49,16 +51,15 @@
 	class:focused={is_focused}
 	data-type="node_array"
 	data-path={path_str}
-	style="anchor-name: --{path.join('-')};{style ? ` ${style}` : ''}" {...rest}
+	style="anchor-name: --{path_str};{style ? ` ${style}` : ''}"
+	{...rest}
 >
 	{#if node_ids.length === 0 && svedit.editable}
 		<div
 			class="empty-node-placeholder"
-			data-path={[...path, 0].join('.')}
+			data-path={serialize_path([...path, 0])}
 			data-type="node"
-			style="anchor-name: --{[...path, 0].join(
-				'-'
-			)}; --node-array-anchor: --{path.join('-')}"
+			style="anchor-name: --{serialize_path([...path, 0])}; --node-array-anchor: --{path_str}"
 		>
 		<NodeGap
 			array_path={path}
@@ -95,7 +96,6 @@
 		<NodeGapMarkers {path} />
 	{/if}
 </svelte:element>
-
 <style>
 .empty-node-placeholder {
 	cursor: pointer;

--- a/src/lib/NodeGap.svelte
+++ b/src/lib/NodeGap.svelte
@@ -1,4 +1,5 @@
 <script>
+	import { serialize_path } from './utils.js';
 	import { getContext } from 'svelte';
 
 	/**
@@ -50,19 +51,19 @@
 
 	let gap_style = $derived.by(() => {
 		if (!is_editable) return '';
-		const arr = array_path.join('-');
 		const prev_idx = offset - 1;
-		const pa = is_first ? `--${arr}-0` : `--${arr}-${prev_idx}`;
-		const next = `--${arr}-${offset}`;
-		const container = `--${arr}`;
+		const pa = is_first
+			? `--${serialize_path([...array_path, 0])}`
+			: `--${serialize_path([...array_path, prev_idx])}`;
+		const next = `--${serialize_path([...array_path, offset])}`;
+		const container = `--${serialize_path(array_path)}`;
 		return `--_pa:${pa};--_next:${next};--_container:${container}`;
 	});
 
 	let anchor_name = $derived.by(() => {
-		if (!is_editable) return '';
-		const arr = array_path.join('-');
-		if (is_first) return `--g-${arr}-0-gap-before`;
-		return `--g-${arr}-${offset - 1}-gap-after`;
+    if (!is_editable) return '';
+		if (is_first) return `--g-${serialize_path([...array_path, 0])}-gap-before`;
+		return `--g-${serialize_path([...array_path, offset - 1])}-gap-after`;
 	});
 </script>
 
@@ -73,7 +74,7 @@
 		class:last={is_last}
 		class:positioned
 		data-type={type}
-		data-gap-array-path={array_path.join('.')}
+  	data-gap-array-path={serialize_path(array_path)}
 		data-gap-offset={offset}
 		style={gap_style}
 	>
@@ -82,7 +83,6 @@
 {:else}
 	<div class="node-gap"></div>
 {/if}
-
 
 <style>
 	.node-gap {

--- a/src/lib/NodeGapMarkers.svelte
+++ b/src/lib/NodeGapMarkers.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { getContext } from 'svelte';
 	import NodeCaret from './NodeCaret.svelte';
+	import { serialize_path } from './utils.js';
 
 	/**
 	 * ┌─────────────────────────────────────────────────────────────────┐
@@ -29,7 +30,7 @@
 	let { path } = $props();
 
 	const svedit = getContext('svedit');
-	let path_str = $derived(path.join('.'));
+	let path_str = $derived(serialize_path(path));
 	// Per-path signal: only re-evaluates when THIS path's gaps change.
 	let gap_signal = $derived(svedit.insertion_gap_data?.get_gaps(path_str));
 	let my_gaps = $derived(gap_signal?.gaps ?? []);

--- a/src/lib/NodeSelectionMarkers.svelte
+++ b/src/lib/NodeSelectionMarkers.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { getContext } from 'svelte';
+	import { serialize_path } from './utils.js';
 
 	const svedit = getContext('svedit');
 	let selected_node_paths = $derived(get_selected_node_paths());
@@ -22,13 +23,13 @@
 {#if svedit.session.selection?.type === 'property'}
 	<div
 		class="selected-property-overlay"
-		style="position-anchor: --{svedit.session.selection.path.join('-')};"
+		style="position-anchor: --{serialize_path(svedit.session.selection.path)};"
 	></div>
 {/if}
 
 {#if selected_node_paths}
-	{#each selected_node_paths as path (path.join('-'))}
-		<div class="selected-node-overlay" style="position-anchor: --{path.join('-')};"></div>
+	{#each selected_node_paths as path (serialize_path(path))}
+		<div class="selected-node-overlay" style="position-anchor: --{serialize_path(path)};"></div>
 	{/each}
 {/if}
 

--- a/src/lib/Session.svelte.js
+++ b/src/lib/Session.svelte.js
@@ -8,6 +8,7 @@ import {
 	apply_op,
 	count_references as doc_count_references,
 	validate_document_schema,
+	is_id_valid,
 	validate_node,
 	get_active_annotation,
 	validate_selection
@@ -67,9 +68,9 @@ export default class Session {
 	 * Tracks paths currently mounted in the DOM. Within one Svedit document, each
 	 * path may be mounted exactly once. Used by NodeArrayProperty to detect
 	 * duplicate mounts in dev mode.
-	 * @type {Set<string>}
+	 * @type {Record<string, true>}
 	 */
-	#mounted_paths = new Set();
+	#mounted_paths = $state.raw({});
 
 	/**
 	 * Registers a path as mounted. Logs an error if the path is
@@ -78,13 +79,13 @@ export default class Session {
 	 * @param {string} path_str
 	 */
 	register_mount(path_str) {
-		if (this.#mounted_paths.has(path_str)) {
+		if (this.#mounted_paths[path_str]) {
 			console.error(
 				`[svedit] Path "${path_str}" is mounted more than once. Within a single Svedit document, each path may be mounted exactly once. To render shared content in multiple places (e.g. header + footer nav), use distinct node_arrays or separate Svedit instances.`
 			);
 			return;
 		}
-		this.#mounted_paths.add(path_str);
+		this.#mounted_paths[path_str] = true;
 	}
 
 	/**
@@ -92,7 +93,7 @@ export default class Session {
 	 * @param {string} path_str
 	 */
 	unregister_mount(path_str) {
-		this.#mounted_paths.delete(path_str);
+		delete this.#mounted_paths[path_str];
 	}
 
 	/**
@@ -109,6 +110,7 @@ export default class Session {
 		this.schema = schema;
 		this.doc = doc;
 		this.config = config;
+		this.validate_doc();
 
 		// Set selection after doc is initialized so validation can work properly
 		this.selection = options.selection ?? null;
@@ -152,6 +154,9 @@ export default class Session {
 	}
 
 	validate_doc() {
+		if (!is_id_valid(this.doc.document_id)) {
+			throw new Error(`Document ${this.doc.document_id} has an invalid id.`);
+		}
 		for (const node of Object.values(this.doc.nodes)) {
 			validate_node(node, this.schema, this.doc.nodes);
 		}

--- a/src/lib/Svedit.svelte
+++ b/src/lib/Svedit.svelte
@@ -3,7 +3,10 @@
 	import {
 		snake_to_pascal,
 		get_char_length,
-		char_to_utf16_offset
+		char_to_utf16_offset,
+		deserialize_path,
+		paths_equal,
+		serialize_path
 	} from './utils.js';
 	import { create_gap_computation } from './node_gap_computation.svelte.js';
 	import DefaultNodeSelectionMarkers from './NodeSelectionMarkers.svelte';
@@ -776,11 +779,11 @@ ${fallback_html}`;
 	function __resolve_node_from_gap(el) {
 		const gap = /** @type {HTMLElement | null} */ (el.closest('[data-gap-array-path]'));
 		if (!gap) return null;
-		const array_path = gap.dataset.gapArrayPath;
+		const array_path = deserialize_path(gap.dataset.gapArrayPath);
 		const offset = parseInt(gap.dataset.gapOffset, 10);
 		const node_idx = offset > 0 ? offset - 1 : 0;
 		return /** @type {HTMLElement | null} */ (
-			canvas_el.querySelector(`[data-path="${array_path}.${node_idx}"][data-type="node"]`)
+			canvas_el.querySelector(`[data-path="${serialize_path([...array_path, node_idx])}"][data-type="node"]`)
 		);
 	}
 
@@ -809,7 +812,7 @@ ${fallback_html}`;
 			focus_node.closest('[data-gap-array-path]')
 		);
 		if (gap_el && focus_node === anchor_node) {
-			const array_path = gap_el.dataset.gapArrayPath.split('.');
+			const array_path = deserialize_path(gap_el.dataset.gapArrayPath);
 			const gap_offset = parseInt(gap_el.dataset.gapOffset, 10);
 			return {
 				type: 'node',
@@ -827,8 +830,8 @@ ${fallback_html}`;
 			?? /** @type {HTMLElement} */ (anchor_node.closest('[data-path][data-type="node"]'));
 		if (!anchor_root) return null;
 
-		let focus_root_path = focus_root.dataset.path.split('.');
-		let anchor_root_path = anchor_root.dataset.path.split('.');
+		let focus_root_path = deserialize_path(focus_root.dataset.path);
+		let anchor_root_path = deserialize_path(anchor_root.dataset.path);
 		let focus_node_depth = focus_root_path.length;
 		let anchor_node_depth = anchor_root_path.length;
 
@@ -838,30 +841,28 @@ ${fallback_html}`;
 		// onto its index within that array.
 		let focus_walked_up = false;
 		let anchor_walked_up = false;
-		while (
-			focus_root_path.slice(0, -1).join('.') !== anchor_root_path.slice(0, -1).join('.')
-		) {
+		while (!paths_equal(focus_root_path.slice(0, -1), anchor_root_path.slice(0, -1))) {
 			if (focus_root_path.length > anchor_root_path.length) {
 				// Focus is deeper — walk it up
 				focus_root = focus_root.parentElement?.closest('[data-path][data-type="node"]');
 				if (!focus_root) return null;
-				focus_root_path = focus_root.dataset.path.split('.');
+				focus_root_path = deserialize_path(focus_root.dataset.path);
 				focus_walked_up = true;
 			} else if (anchor_root_path.length > focus_root_path.length) {
 				// Anchor is deeper — walk it up
 				anchor_root = anchor_root.parentElement?.closest('[data-path][data-type="node"]');
 				if (!anchor_root) return null;
-				anchor_root_path = anchor_root.dataset.path.split('.');
+				anchor_root_path = deserialize_path(anchor_root.dataset.path);
 				anchor_walked_up = true;
 			} else {
 				// Same depth but different node arrays — walk both up
 				focus_root = focus_root.parentElement?.closest('[data-path][data-type="node"]');
 				if (!focus_root) return null;
-				focus_root_path = focus_root.dataset.path.split('.');
+				focus_root_path = deserialize_path(focus_root.dataset.path);
 				focus_walked_up = true;
 				anchor_root = anchor_root.parentElement?.closest('[data-path][data-type="node"]');
 				if (!anchor_root) return null;
-				anchor_root_path = anchor_root.dataset.path.split('.');
+				anchor_root_path = deserialize_path(anchor_root.dataset.path);
 				anchor_walked_up = true;
 			}
 		}
@@ -875,8 +876,8 @@ ${fallback_html}`;
 		const parent_property = session.inspect(parent_array_path);
 		if (!parent_property || parent_property.type !== 'node_array') return null;
 
-		let anchor_offset = parseInt(anchor_root_path.at(-1));
-		let focus_offset = parseInt(focus_root_path.at(-1));
+		let anchor_offset = Number(anchor_root_path.at(-1));
+		let focus_offset = Number(focus_root_path.at(-1));
 
 		// Check if it's a backwards selection
 		const is_backwards = __is_dom_selection_backwards();
@@ -940,7 +941,7 @@ ${fallback_html}`;
 		if (focus_root === anchor_root) {
 			return {
 				type: 'property',
-				path: focus_root.dataset.path.split('.')
+				path: deserialize_path(focus_root.dataset.path)
 			};
 		}
 		return null;
@@ -1014,7 +1015,7 @@ ${fallback_html}`;
 			return null;
 		}
 
-		const path = focus_root.dataset.path.split('.');
+		const path = deserialize_path(focus_root.dataset.path);
 
 		if (!path) return null;
 
@@ -1085,18 +1086,19 @@ ${fallback_html}`;
 
 	function __get_node_element(node_array_path, node_offset) {
 		return canvas_el.querySelector(
-			`[data-path="${node_array_path}.${node_offset}"][data-type="node"]`
+			`[data-path="${serialize_path([...node_array_path, node_offset])}"][data-type="node"]`
 		);
 	}
 
 	function __render_node_selection() {
 		const selection = /** @type {NodeSelection} */ (session.selection);
-		const node_array_path = selection.path.join('.');
+		const node_array_path = selection.path;
+		const node_array_path_str = serialize_path(node_array_path);
 		const is_collapsed = selection.anchor_offset === selection.focus_offset;
 		const is_backward = !is_collapsed && selection.anchor_offset > selection.focus_offset;
 
 		const node_array_el = canvas_el.querySelector(
-			`[data-path="${node_array_path}"][data-type="node_array"]`
+			`[data-path="${node_array_path_str}"][data-type="node_array"]`
 		);
 		if (!node_array_el) return;
 
@@ -1104,7 +1106,7 @@ ${fallback_html}`;
 		const range = window.document.createRange();
 
 		const gap_selector = (offset) =>
-			`[data-gap-array-path="${node_array_path}"][data-gap-offset="${offset}"]`;
+			`[data-gap-array-path="${node_array_path_str}"][data-gap-offset="${offset}"]`;
 
 		if (is_collapsed) {
 			const gap_el = node_array_el.querySelector(gap_selector(selection.anchor_offset));
@@ -1153,7 +1155,7 @@ ${fallback_html}`;
 		const selection = session.selection;
 		// The element that holds the property
 		const el = canvas_el.querySelector(
-			`[data-path="${selection.path.join('.')}"][data-type="property"]`
+			`[data-path="${serialize_path(selection.path)}"][data-type="property"]`
 		);
 
 		const gap_selectable = el.querySelector('.svedit-selectable');
@@ -1176,7 +1178,7 @@ ${fallback_html}`;
 		const selection = /** @type {any} */ (session.selection);
 		// The element that holds the annotated string
 		const el = canvas_el.querySelector(
-			`[data-path="${selection.path.join('.')}"][data-type="text"]`
+			`[data-path="${serialize_path(selection.path)}"][data-type="text"]`
 		);
 		const empty_text = session.get(selection.path).text.length === 0;
 		const dom_selection = window.getSelection();

--- a/src/lib/doc_utils.js
+++ b/src/lib/doc_utils.js
@@ -7,7 +7,13 @@
  * @import { NodeId, DocumentPath, PrimitiveType, NodeProperty, NodeArrayProperty, NodeSchema, DocumentSchema, Selection, Annotation, Document } from './types'
  */
 
-import { get_selection_range, get_char_length } from './utils.js';
+import {
+	assert_path_string_segment,
+	is_path_string_segment_valid,
+	get_selection_range,
+	get_char_length,
+	serialize_path
+} from './utils.js';
 
 /**
  * Identity function — keeps schema at runtime & makes IDE infer types.
@@ -66,6 +72,7 @@ export function validate_document_schema(document_schema) {
 	// Check that all referenced node types exist
 	for (const [node_type, node_schema] of Object.entries(document_schema)) {
 		for (const [prop_name, prop_def] of Object.entries(node_schema.properties)) {
+			assert_path_string_segment(prop_name, `Property name "${prop_name}"`);
 			if (prop_def.type === 'node' || prop_def.type === 'node_array') {
 				const missing_types = prop_def.node_types.filter(
 					(ref_type) => !(ref_type in document_schema)
@@ -122,8 +129,8 @@ function validate_primitive_value(type, value) {
  * @param {string} id
  * @returns {boolean}
  */
-function is_id_valid(id) {
-	return typeof id === 'string' && id.length > 0;
+export function is_id_valid(id) {
+	return typeof id === 'string' && id.length > 0 && is_path_string_segment_valid(id);
 }
 
 /**
@@ -535,7 +542,7 @@ export function validate_selection(selection, session_or_transaction) {
 		}
 	} else if (selection_type === 'property') {
 		if (!session_or_transaction.inspect(selection.path)) {
-			throw new Error(`Property selection path not found: ${selection.path.join('.')}`);
+			throw new Error(`Property selection path not found: ${serialize_path(selection.path)}`);
 		}
 	}
 }

--- a/src/lib/node_gap_computation.svelte.js
+++ b/src/lib/node_gap_computation.svelte.js
@@ -5,6 +5,8 @@
  * @module
  */
 
+import { deserialize_path, serialize_path } from './utils.js';
+
 /**
  * IntersectionObserver-based viewport tracking for node arrays.
  *
@@ -126,11 +128,10 @@ function node_ids_equal(a, b) {
  * @returns {{ array_path: string, child_index: number } | null}
  */
 function parse_node_path(path) {
-	const dot = path.lastIndexOf('.');
-	if (dot < 0) return null;
-	const child_index = parseInt(path.slice(dot + 1), 10);
-	if (Number.isNaN(child_index)) return null;
-	return { array_path: path.slice(0, dot), child_index };
+	const path_segments = deserialize_path(path);
+	const child_index = path_segments.at(-1);
+	if (typeof child_index !== 'number') return null;
+	return { array_path: serialize_path(path_segments.slice(0, -1)), child_index };
 }
 
 /**
@@ -140,7 +141,7 @@ function parse_node_path(path) {
  *   readonly doc_snapshot: object | null,
  *   readonly array_ver_map: Map<string, number>,
  *   is_near_viewport: (path: Array<string|number>) => boolean,
- *   should_position_gap: (array_path: Array<string|number>, offset: number, count: number) => boolean
+ *   should_position_gap: (array_path: Array<string|number> | string, offset: number, count: number) => boolean
  * }}
  */
 function create_visibility_culler(svedit) {
@@ -488,7 +489,7 @@ function create_visibility_culler(svedit) {
 		if (path.length < 2) return true;
 		const child_index = path[path.length - 1];
 		if (typeof child_index !== 'number') return true;
-		const set = index_map.get(path.slice(0, -1).join('.'));
+		const set = index_map.get(serialize_path(path.slice(0, -1)));
 		return set ? set.has(child_index) : false;
 	}
 
@@ -515,17 +516,17 @@ function create_visibility_culler(svedit) {
 		void version;
 		const array_path_str = typeof array_path === 'string'
 			? array_path
-			: array_path.join('.');
+			: serialize_path(array_path);
 		const set = index_map.get(array_path_str);
 
 		if (offset === 0) {
 			if (!set || !set.has(0)) return false;
-			return ((clip_map.get(`${array_path_str}.0`) ?? 0) & 0b01) === 0;
+			return ((clip_map.get(serialize_path([...deserialize_path(array_path_str), 0])) ?? 0) & 0b01) === 0;
 		}
 		if (offset === count) {
 			const last = count - 1;
 			if (!set || !set.has(last)) return false;
-			return ((clip_map.get(`${array_path_str}.${last}`) ?? 0) & 0b10) === 0;
+			return ((clip_map.get(serialize_path([...deserialize_path(array_path_str), last])) ?? 0) & 0b10) === 0;
 		}
 		return !!set && set.has(offset - 1) && set.has(offset);
 	}
@@ -573,7 +574,7 @@ export function create_gap_computation(svedit) {
 	let caret_gap_key = $derived.by(() => {
 		const s = svedit.session.selection;
 		if (s?.type !== 'node' || s.anchor_offset !== s.focus_offset) return null;
-		return `${s.path.join('.')}-gap-${s.anchor_offset}`;
+		return `${serialize_path(s.path)}-gap-${s.anchor_offset}`;
 	});
 
 	/**
@@ -685,7 +686,7 @@ export function create_gap_computation(svedit) {
 	 * @returns {Map<string, Array<gap_t>>}
 	 */
 	function build_all_gaps() {
-		if (!svedit.editable) return new Map();
+		if (!svedit.editable) return new Map(); // eslint-disable-line svelte/prefer-svelte-reactivity
 
 		/** @type {Map<string, Array<gap_t>>} */
 		const by_path = new Map(); // eslint-disable-line svelte/prefer-svelte-reactivity
@@ -732,7 +733,7 @@ export function create_gap_computation(svedit) {
 			return cached.gaps;
 		}
 
-		const array_path = array_path_str.split('.');
+		const array_path = deserialize_path(array_path_str);
 		let node_ids = null;
 		try {
 			const info = svedit.session.inspect(array_path);
@@ -779,13 +780,12 @@ export function create_gap_computation(svedit) {
 	 * @returns {Array<gap_t>}
 	 */
 	function emit_gaps(array_path_str, array_path, count, is_visible) {
-		const anchor_prefix = `--${array_path.join('-')}`;
-		const g_prefix = `--g-${array_path.join('-')}`;
-		const container_var = `;--_c:${anchor_prefix}`;
+		const node_anchor = (index) => `--${serialize_path([...array_path, index])}`;
+		const gap_before_anchor = (index) => `--g-${serialize_path([...array_path, index])}-gap-before`;
+		const gap_after_anchor = (index) => `--g-${serialize_path([...array_path, index])}-gap-after`;
+		const container_var = `;--_c:--${serialize_path(array_path)}`;
 		const has_pair = count >= 2;
-		const pair_vars = has_pair
-			? `;--_f:${anchor_prefix}-0;--_s:${anchor_prefix}-1`
-			: '';
+		const pair_vars = has_pair ? `;--_f:${node_anchor(0)};--_s:${node_anchor(1)}` : '';
 
 		/** @type {Array<gap_t>} */
 		const gaps = [];
@@ -796,7 +796,7 @@ export function create_gap_computation(svedit) {
 				path: array_path,
 				offset: 0,
 				type: 'gap-empty',
-				vars: `--_ct:${g_prefix}-0-gap-before;--_a:${anchor_prefix}-0${container_var}`,
+				vars: `--_ct:${gap_before_anchor(0)};--_a:${node_anchor(0)}${container_var}`,
 				is_first: true,
 				is_last: true,
 				has_pair: false
@@ -809,22 +809,18 @@ export function create_gap_computation(svedit) {
 
 			const is_first = offset === 0;
 			const is_last = offset === count;
-			const g_anchor = offset === 0
-				? `${g_prefix}-0-gap-before`
-				: `${g_prefix}-${offset - 1}-gap-after`;
+			const g_anchor = offset === 0 ? gap_before_anchor(0) : gap_after_anchor(offset - 1);
 
 			let type, vars;
 
 			if (is_first || is_last) {
 				type = 'gap-edge';
-				const adjacent = is_first
-					? `${anchor_prefix}-0`
-					: `${anchor_prefix}-${count - 1}`;
+				const adjacent = is_first ? node_anchor(0) : node_anchor(count - 1);
 				vars = `--_ct:${g_anchor};--_a:${adjacent}${container_var}${pair_vars}`;
 			} else {
 				type = 'gap-mid';
-				const p_anchor = `${anchor_prefix}-${offset - 1}`;
-				const n_anchor = `${anchor_prefix}-${offset}`;
+				const p_anchor = node_anchor(offset - 1);
+				const n_anchor = node_anchor(offset);
 				vars = `--_ct:${g_anchor};--_p:${p_anchor};--_n:${n_anchor}${container_var}${pair_vars}`;
 			}
 

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -11,12 +11,17 @@ import type { Component, Snippet } from 'svelte';
 // ===== SELECTION TYPE DEFINITIONS =====
 
 /**
- * A unique node identifier (ideally UUID)
+ * A unique node identifier.
+ *
+ * Node ids must be valid Svedit path string segments: they must start with
+ * a letter or underscore, contain only letters, numbers, underscores, or
+ * dashes, and must not contain `__`.
  */
 export type NodeId = string;
 
 /**
- * Array of IDs, property names (strings), or indexes (integers) that identify a node or property in the document
+ * Array of IDs, property names (strings), or indexes (integers) that identify a node or property in the document.
+ * String segments must follow the same path segment rules as NodeId.
  */
 export type DocumentPath = Array<string | number>;
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -21,7 +21,7 @@ export function is_mobile_browser() {
 	);
 }
 
-// ‼️‼️‼️‼️‼️‼️ UNUSED UTILITY BELOW ‼️‼️‼️‼️‼️‼️ 
+// ‼️‼️‼️‼️‼️‼️ UNUSED UTILITY BELOW ‼️‼️‼️‼️‼️‼️
 /**
  * Detect if the current browser is Chrome on desktop
  * @returns {boolean} true if Chrome desktop browser, false otherwise
@@ -54,8 +54,7 @@ export function get_char_length(str) {
 	return [...SEGMENTER.segment(str)].length;
 }
 
-
-// ‼️‼️‼️‼️‼️‼️ UNUSED UTILITY BELOW ‼️‼️‼️‼️‼️‼️ 
+// ‼️‼️‼️‼️‼️‼️ UNUSED UTILITY BELOW ‼️‼️‼️‼️‼️‼️
 /**
  * Get a single character at the specified position (accounting for multi-byte characters)
  *
@@ -276,6 +275,113 @@ export function snake_to_pascal(str) {
 		.split('_')
 		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
 		.join('');
+}
+
+const PATH_SEPARATOR = '__';
+const PATH_STRING_SEGMENT_RE = /^[A-Za-z_][A-Za-z0-9_-]*$/;
+const PATH_INDEX_SEGMENT_RE = /^(0|[1-9]\d*)$/;
+
+/**
+ * Check whether a string can be used as a Svedit path segment.
+ *
+ * Path string segments include node ids and schema property names. Keeping
+ * them restricted makes serialized paths reversible, valid as HTML ids, and
+ * safe to use as CSS anchor-name suffixes.
+ *
+ * @param {string} segment
+ * @returns {boolean}
+ */
+export function is_path_string_segment_valid(segment) {
+	return (
+		typeof segment === 'string' &&
+		PATH_STRING_SEGMENT_RE.test(segment) &&
+		!segment.includes(PATH_SEPARATOR)
+	);
+}
+
+/**
+ * Assert that a string can be used as a Svedit path segment.
+ *
+ * @param {string} segment
+ * @param {string} [label]
+ * @returns {void}
+ */
+export function assert_path_string_segment(segment, label = 'Path segment') {
+	if (!is_path_string_segment_valid(segment)) {
+		throw new Error(
+			`${label} must start with a letter or underscore and contain only letters, numbers, underscores, or dashes. It must not contain "${PATH_SEPARATOR}".`
+		);
+	}
+}
+
+/**
+ * Serialize a document path while preserving whether each segment is a
+ * property/key string or an array index number.
+ *
+ * The result is reversible and safe to use as a data attribute value, HTML id,
+ * or CSS anchor-name suffix.
+ *
+ * @param {Array<string | number>} path
+ * @returns {string}
+ *
+ * @example
+ * serialize_path(['page_1', 'body', 0, 'items']) // Returns: 'page_1__body__0__items'
+ */
+export function serialize_path(path) {
+	return path
+		.map((segment) => {
+			if (typeof segment === 'number') {
+				if (!Number.isInteger(segment) || segment < 0) {
+					throw new Error(`Path index must be a non-negative integer: ${segment}`);
+				}
+				return String(segment);
+			}
+
+			assert_path_string_segment(segment);
+			return segment;
+		})
+		.join(PATH_SEPARATOR);
+}
+
+/**
+ * Deserialize a path string produced by serialize_path.
+ *
+ * @param {string} serialized_path
+ * @returns {Array<string | number>}
+ *
+ * @example
+ * deserialize_path('page_1__body__0__items') // Returns: ['page_1', 'body', 0, 'items']
+ */
+export function deserialize_path(serialized_path) {
+	if (serialized_path === '') return [];
+
+	return serialized_path.split(PATH_SEPARATOR).map((segment) => {
+		if (segment === '') {
+			throw new Error(`Invalid serialized path: ${serialized_path}`);
+		}
+
+		if (/^\d+$/.test(segment)) {
+			if (!PATH_INDEX_SEGMENT_RE.test(segment)) {
+				throw new Error(`Invalid serialized path index: ${segment}`);
+			}
+			return Number(segment);
+		}
+
+		assert_path_string_segment(segment, 'Serialized path segment');
+		return segment;
+	});
+}
+
+/**
+ * Compare two document paths segment-by-segment, preserving segment types.
+ *
+ * @param {Array<string | number>} a
+ * @param {Array<string | number>} b
+ * @returns {boolean}
+ */
+export function paths_equal(a, b) {
+	if (a.length !== b.length) return false;
+	return a.every((segment, index) => segment === b[index]);
 }
 
 export function traverse(node_id, schema, nodes) {

--- a/src/routes/components/Highlight.svelte
+++ b/src/routes/components/Highlight.svelte
@@ -1,11 +1,14 @@
 <script>
 	import { getContext } from 'svelte';
+	import { serialize_path } from '../../lib/utils.js';
 	const svedit = getContext('svedit');
 	let { path, content } = $props();
 	let node = $derived(svedit.session.get(path));
 </script>
 
-<mark id={node.id} data-node-id={node.id} style="anchor-name: --{path.join('-')};">{content}</mark>
+<mark id={node.id} data-node-id={node.id} style="anchor-name: --{serialize_path(path)};"
+	>{content}</mark
+>
 
 <style>
 	mark {

--- a/src/routes/components/Link.svelte
+++ b/src/routes/components/Link.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { getContext } from 'svelte';
+	import { serialize_path } from '../../lib/utils.js';
 	const svedit = getContext('svedit');
 	let { path, content } = $props();
 	let node = $derived(svedit.session.get(path));
@@ -10,5 +11,5 @@
 	data-node-id={node.id}
 	href={node?.href}
 	target={node?.target || '_self'}
-	style="anchor-name: --{path.join('-')};">{content}</a
+	style="anchor-name: --{serialize_path(path)};">{content}</a
 >

--- a/src/routes/components/LinkActionOverlay.svelte
+++ b/src/routes/components/LinkActionOverlay.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { getContext } from 'svelte';
 	import Icon from './Icon.svelte';
+	import { serialize_path } from '../../lib/utils.js';
 
 	const svedit = getContext('svedit');
 	let active_link_path = $derived(get_active_link_path());
@@ -24,7 +25,7 @@
 </script>
 
 {#if active_link_path}
-	<div class="link-action-overlay" style="position-anchor: --{active_link_path.join('-')};">
+	<div class="link-action-overlay" style="position-anchor: --{serialize_path(active_link_path)};">
 		<a href={active_link?.href} target="_blank" class="small"><Icon name="external-link" /></a>
 	</div>
 {/if}

--- a/src/test/Session.svelte.test.js
+++ b/src/test/Session.svelte.test.js
@@ -1,5 +1,52 @@
 import { describe, it, expect } from 'vitest';
+import Session from '../lib/Session.svelte.js';
+import { deserialize_path, serialize_path } from '../lib/utils.js';
 import create_test_session from './create_test_session.js';
+
+describe('path serialization', () => {
+	it('should preserve string and number path segment semantics', () => {
+		const path = ['page_1', 'body', 0, 'items'];
+		const serialized_path = serialize_path(path);
+
+		expect(serialized_path).toBe('page_1__body__0__items');
+		expect(deserialize_path(serialized_path)).toEqual(path);
+	});
+
+	it('should reject path string segments that cannot be represented in the unified format', () => {
+		expect(() => serialize_path(['page.1'])).toThrow('Path segment');
+		expect(() => serialize_path(['page__1'])).toThrow('Path segment');
+		expect(() => serialize_path(['1_page'])).toThrow('Path segment');
+	});
+});
+
+describe('schema path segment validation', () => {
+	it('should throw when schema property names cannot be represented in the unified path format', () => {
+		expect(
+			() =>
+				new Session(
+					{
+						page: {
+							kind: 'document',
+							properties: {
+								'bad.property': { type: 'string' }
+							}
+						}
+					},
+					{
+						document_id: 'page_1',
+						nodes: {
+							page_1: {
+								id: 'page_1',
+								type: 'page',
+								'bad.property': ''
+							}
+						}
+					},
+					{}
+				)
+		).toThrow('Property name');
+	});
+});
 
 describe('Session.svelte.js', () => {
 	it('should be traversable', () => {
@@ -67,6 +114,22 @@ describe('Session.svelte.js', () => {
 			const title_info = session.inspect(['page_1', 'body', 0, 'title']);
 			expect(title_info.kind).toBe('property');
 			expect(title_info.type).toBe('annotated_text');
+		});
+	});
+
+	describe('Node id validation', () => {
+		it('should throw when creating a node with an id that starts with a number', () => {
+			const session = create_test_session();
+			const tr = session.tr;
+
+			expect(() =>
+				tr.create({
+					id: '1_invalid_node',
+					type: 'text',
+					layout: 1,
+					content: { text: 'Invalid node', annotations: [] }
+				})
+			).toThrow('invalid id');
 		});
 	});
 


### PR DESCRIPTION
Switch path handling to serialized "__"-separated strings for data-path, anchor names, and position anchors. Add serialize_path/deserialize_path and path-segment validation, use paths_equal where appropriate, migrate mounted_paths to a reactive record, update node-gap parsing, and add tests for path serialization and node id validation.