### PR TITLE
Remove arbitrary parent traversal limit

### DIFF
--- a/src/lib/Command.svelte.js
+++ b/src/lib/Command.svelte.js
@@ -90,14 +90,16 @@ export class RedoCommand extends Command {
 /**
  * Command that selects the parent of the current selection.
  * Useful for navigating up the document hierarchy.
+ *
+ * Enabled whenever there is any selection — `select_parent()` walks the
+ * document graph to find the containing array, so paths that don't encode
+ * the parent (every node selection, top-level text selections) still
+ * climb correctly. The previous `path.length > 3` gate was a string-only
+ * heuristic that silently disabled climbing for nested arrays.
  */
 export class SelectParentCommand extends Command {
 	is_enabled() {
-		return (
-			this.context.editable &&
-			this.context.session.selection &&
-			this.context.session.selection.path.length > 3
-		);
+		return this.context.editable && !!this.context.session.selection;
 	}
 
 	execute() {

--- a/src/lib/Command.svelte.js
+++ b/src/lib/Command.svelte.js
@@ -89,13 +89,7 @@ export class RedoCommand extends Command {
 
 /**
  * Command that selects the parent of the current selection.
- * Useful for navigating up the document hierarchy.
- *
- * Enabled whenever there is any selection — `select_parent()` walks the
- * document graph to find the containing array, so paths that don't encode
- * the parent (every node selection, top-level text selections) still
- * climb correctly. The previous `path.length > 3` gate was a string-only
- * heuristic that silently disabled climbing for nested arrays.
+ * Enabled whenever there is any selection.
  */
 export class SelectParentCommand extends Command {
 	is_enabled() {

--- a/src/lib/Session.svelte.js
+++ b/src/lib/Session.svelte.js
@@ -473,41 +473,101 @@ export default class Session {
 		return $state.snapshot(node_array.slice(start, end));
 	}
 
+	/**
+	 * Find which node has `child_id` in any of its node-array properties.
+	 * Returns the parent's id, the array property name, and the index of the
+	 * child within that array — or null if no parent contains it (i.e.
+	 * `child_id` is the doc root, or the graph is disconnected).
+	 *
+	 * @param {string} child_id
+	 * @returns {{ parent_id: string, prop_name: string, index: number } | null}
+	 */
+	_find_node_parent(child_id) {
+		for (const [nid, node] of Object.entries(this.doc.nodes)) {
+			const node_schema = this.schema[node.type];
+			if (!node_schema) continue;
+			for (const [prop_name, prop_def] of Object.entries(node_schema.properties)) {
+				if (prop_def.type !== 'node_array') continue;
+				const arr = node[prop_name];
+				if (!Array.isArray(arr)) continue;
+				const idx = arr.indexOf(child_id);
+				if (idx >= 0) return { parent_id: nid, prop_name, index: idx };
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Move the selection up one level in the document hierarchy.
+	 *
+	 * Three cases:
+	 *
+	 *   1. Path encodes the parent already (text/property length ≥ 4, or
+	 *      node selection length ≥ 4). The last two segments are
+	 *      `[index, prop_name]` of the current subject inside its parent
+	 *      array — drop them to reach the array, and use that index as
+	 *      the offset.
+	 *
+	 *   2. Short paths (length 2): for both short text/property selections
+	 *      (`[block_id, 'content']`) and short node selections
+	 *      (`[array_owner_id, prop_name]`) the path doesn't say which
+	 *      array contains the subject, so we walk the document graph.
+	 *
+	 *   3. Reaching the doc root with no parent clears the selection.
+	 */
 	select_parent() {
 		if (!this.selection) return;
-		if (['text', 'property'].includes(this.selection?.type)) {
-			// For text and property selections (e.g. ['page_1', 'body', 0, 'image']), we need to go up two levels
-			// in the path
-			if (this.selection.path.length > 3) {
-				const parent_path = this.selection.path.slice(0, -2);
-				const current_index = parseInt(String(this.selection.path[this.selection.path.length - 2]));
-				this.selection = {
-					type: 'node',
-					path: parent_path,
-					anchor_offset: current_index,
-					focus_offset: current_index + 1
-				};
-			} else {
-				this.selection = null;
-			}
-		} else if (this.selection.type === 'node') {
-			// For node selections, we go up one level
-			if (this.selection.path.length > 3) {
-				const parent_path = this.selection.path.slice(0, -2);
-				const current_index = parseInt(String(this.selection.path[this.selection.path.length - 2]));
+		const sel = this.selection;
 
-				this.selection = {
-					type: 'node',
-					path: parent_path,
-					anchor_offset: current_index,
-					focus_offset: current_index + 1
-				};
-			} else {
-				this.selection = null;
-			}
-		} else {
-			this.selection = null;
+		// Case 1a — nested text/property: path = [..., array_idx, prop_name]
+		// at length ≥ 4. Drop the trailing pair to land on the containing
+		// array with the index offset.
+		if ((sel.type === 'text' || sel.type === 'property') && sel.path.length >= 4) {
+			const parent_path = sel.path.slice(0, -2);
+			const current_index = parseInt(String(sel.path[sel.path.length - 2]));
+			this.selection = {
+				type: 'node',
+				path: parent_path,
+				anchor_offset: current_index,
+				focus_offset: current_index + 1
+			};
+			return;
 		}
+
+		// Case 1b — nested node selection: path = [..., array_idx, prop_name]
+		// at length ≥ 4. The current selection is on children inside an
+		// inner array. Climb one level by dropping the trailing
+		// `[idx, prop_name]` pair so the subject (the node at that
+		// position) becomes selected within the outer array.
+		if (sel.type === 'node' && sel.path.length >= 4) {
+			const parent_path = sel.path.slice(0, -2);
+			const current_index = parseInt(String(sel.path[sel.path.length - 2]));
+			this.selection = {
+				type: 'node',
+				path: parent_path,
+				anchor_offset: current_index,
+				focus_offset: current_index + 1
+			};
+			return;
+		}
+
+		// Case 2 — short paths. Graph walk to find the subject's parent.
+		const subject_id = sel.path[0];
+		if (!subject_id) {
+			this.selection = null;
+			return;
+		}
+		const parent = this._find_node_parent(subject_id);
+		if (!parent) {
+			this.selection = null;
+			return;
+		}
+		this.selection = {
+			type: 'node',
+			path: [parent.parent_id, parent.prop_name],
+			anchor_offset: parent.index,
+			focus_offset: parent.index + 1
+		};
 	}
 
 	/**

--- a/src/lib/Session.svelte.js
+++ b/src/lib/Session.svelte.js
@@ -500,31 +500,18 @@ export default class Session {
 	/**
 	 * Move the selection up one level in the document hierarchy.
 	 *
-	 * Three cases:
-	 *
-	 *   1. Path encodes the parent already (text/property length ≥ 4, or
-	 *      node selection length ≥ 4). The last two segments are
-	 *      `[index, prop_name]` of the current subject inside its parent
-	 *      array — drop them to reach the array, and use that index as
-	 *      the offset.
-	 *
-	 *   2. Short paths (length 2): for both short text/property selections
-	 *      (`[block_id, 'content']`) and short node selections
-	 *      (`[array_owner_id, prop_name]`) the path doesn't say which
-	 *      array contains the subject, so we walk the document graph.
-	 *
-	 *   3. Reaching the doc root with no parent clears the selection.
+	 * Long paths (≥ 4 segments) encode the parent inline — drop the
+	 * trailing `[index, prop_name]` pair. Short paths (length 2) don't
+	 * encode the parent, so we walk the document graph. Clears selection
+	 * when the root is reached.
 	 */
 	select_parent() {
 		if (!this.selection) return;
 		const sel = this.selection;
 
-		// Case 1a — nested text/property: path = [..., array_idx, prop_name]
-		// at length ≥ 4. Drop the trailing pair to land on the containing
-		// array with the index offset.
-		if ((sel.type === 'text' || sel.type === 'property') && sel.path.length >= 4) {
+		if (sel.path.length >= 4) {
 			const parent_path = sel.path.slice(0, -2);
-			const current_index = parseInt(String(sel.path[sel.path.length - 2]));
+			const current_index = parseInt(String(sel.path[sel.path.length - 2]), 10);
 			this.selection = {
 				type: 'node',
 				path: parent_path,
@@ -534,30 +521,9 @@ export default class Session {
 			return;
 		}
 
-		// Case 1b — nested node selection: path = [..., array_idx, prop_name]
-		// at length ≥ 4. The current selection is on children inside an
-		// inner array. Climb one level by dropping the trailing
-		// `[idx, prop_name]` pair so the subject (the node at that
-		// position) becomes selected within the outer array.
-		if (sel.type === 'node' && sel.path.length >= 4) {
-			const parent_path = sel.path.slice(0, -2);
-			const current_index = parseInt(String(sel.path[sel.path.length - 2]));
-			this.selection = {
-				type: 'node',
-				path: parent_path,
-				anchor_offset: current_index,
-				focus_offset: current_index + 1
-			};
-			return;
-		}
-
-		// Case 2 — short paths. Graph walk to find the subject's parent.
+		// Short path — graph walk to find the containing array.
 		const subject_id = sel.path[0];
-		if (!subject_id) {
-			this.selection = null;
-			return;
-		}
-		const parent = this._find_node_parent(subject_id);
+		const parent = subject_id ? this._find_node_parent(subject_id) : null;
 		if (!parent) {
 			this.selection = null;
 			return;


### PR DESCRIPTION
## Problem

When pressing ESC repeatedly to climb the document hierarchy, the selection would abruptly disappear at certain nesting levels instead of continuing to climb.

The root cause: `select_parent` navigated upward by slicing 2 segments off the selection path on each call (`['page_1', 'body', 3, 'buttons', 1, 'label']` → `['page_1', 'body', 3, 'buttons']` → `['page_1', 'body']`). But it only did this when `path.length > 3`. Once the path reached length 2 — e.g. `['page_1', 'body']`, meaning "a node selection on page_1's body array" — it hit the `else` branch and cleared the selection entirely.

The issue is that at length 2, the path no longer encodes who the *parent* of `page_1` is. The old code had no way to answer "which array contains `page_1`?" so it gave up. This meant the last possible climb (from a top-level array up to the node that owns it within *its* parent array) was never reachable.

## Fix

When the path is too short to encode the parent (length < 4), walk the document graph (`_find_node_parent`) to find which node holds the subject in one of its `node_array` properties. This resolves the final hop. If no parent exists (i.e. we've reached the document root), selection is cleared as before.

## How to test

1. Open a document with deeply nested node arrays
2. Click into text inside the nested content
3. Press ESC repeatedly — selection should climb through each level of the hierarchy before finally clearing at the root