### PR TITLE
Fix caret jumping to offset 0 when clicking into text

### DIFF
--- a/src/lib/Svedit.svelte
+++ b/src/lib/Svedit.svelte
@@ -703,9 +703,6 @@ ${fallback_html}`;
 		const selection = /** @type {Selection} */ (session.selection);
 
 		if (!selection) {
-			// No model selection -> just leave things as they are
-			let dom_selection = window.getSelection();
-			dom_selection.removeAllRanges();
 			return;
 		}
 


### PR DESCRIPTION
## Summary
- Removes `removeAllRanges()` from `render_selection()` when `session.selection` is null
- Fixes caret being placed in front of the first letter instead of at the click position when clicking a text property from outside the canvas

## Root cause
`handle_canvas_focus` sets `session.selection = null` and flushes synchronously. The `$effect` for `render_selection` fires during `flushSync`, sees no selection, and calls `removeAllRanges()` — wiping the browser's pending click selection. The browser falls back to offset 0.

## Test plan
- [ ] Click into a text property from outside the canvas, verify caret lands at click position
- [ ] Click into a text property that has a visible (blurred) selection highlight, verify caret lands correctly
- [ ] Verify existing selection behavior (arrow keys, shift-select, etc.) is unaffected

Made with [Cursor](https://cursor.com)