### PR TITLE
Fix caret vertical alignment in empty text properties with placeholders

### DIFF
--- a/src/lib/AnnotatedTextProperty.svelte
+++ b/src/lib/AnnotatedTextProperty.svelte
@@ -167,6 +167,27 @@
 		color: color-mix(in oklch, currentcolor 50%, transparent);
 	}
 
+	/* A virtual caret: to fix the caret vertical alignment issue in Chrome and Firefox for empty focused contenteditable with placeholders */
+	[placeholder].editable.empty.focused  {
+		caret-color: transparent;
+	}
+	[placeholder].editable.empty.focused::before {
+    content: "";
+		/* we limit width & height to avoid layout shifts in case the text has a lower natural height */
+    width: 0px;
+    height: 1cap;
+    display: inline-block;
+		/* we use box-shadow to draw the caret shape, matching the native caret */
+    box-shadow: 
+			0 -0.4cap 0 0.65px var(--svedit-caret-color, AccentColor),
+			0 0 0 0.65px var(--svedit-caret-color, AccentColor),
+			0 0.4cap 0 0.65px var(--svedit-caret-color, AccentColor);
+		animation: var(
+			--node-caret-animation,
+			node-caret-blink var(--node-caret-blink-duration, 1.1s) ease-in-out infinite
+		);
+	}
+
 	/* Hide flickering: in Chrome, the caret jumps from end of placeholder string to start of text property when we focus */
 	.text:not(.focused) {
 		caret-color: transparent;

--- a/src/lib/AnnotatedTextProperty.svelte
+++ b/src/lib/AnnotatedTextProperty.svelte
@@ -168,7 +168,7 @@
 	}
 
 	/* A virtual caret: to fix the caret vertical alignment issue in Chrome and Firefox for empty focused contenteditable with placeholders */
-	[placeholder].editable.empty.focused  {
+	.empty  {
 		caret-color: transparent;
 	}
 	[placeholder].editable.empty.focused::before {

--- a/src/lib/AnnotatedTextProperty.svelte
+++ b/src/lib/AnnotatedTextProperty.svelte
@@ -168,8 +168,10 @@
 	}
 
 	/* A virtual caret: to fix the caret vertical alignment issue in Chrome and Firefox for empty focused contenteditable with placeholders */
-	.empty  {
-		caret-color: red !important;
+    /* Browser BUG: iOS Safari only considers the caret color set on the top contenteditable element, not on nested elements (e.g. the second selector doesn't work in iOS Safari) */
+	:global(.svedit-canvas:has([placeholder].editable.empty.focused)), 
+    [placeholder].editable.empty.focused {
+		caret-color: transparent !important;
 	}
 	[placeholder].editable.empty.focused::before {
     content: "";

--- a/src/lib/AnnotatedTextProperty.svelte
+++ b/src/lib/AnnotatedTextProperty.svelte
@@ -169,7 +169,7 @@
 
 	/* A virtual caret: to fix the caret vertical alignment issue in Chrome and Firefox for empty focused contenteditable with placeholders */
 	.empty  {
-		caret-color: transparent;
+		caret-color: red !important;
 	}
 	[placeholder].editable.empty.focused::before {
     content: "";

--- a/src/lib/AnnotatedTextProperty.svelte
+++ b/src/lib/AnnotatedTextProperty.svelte
@@ -159,6 +159,27 @@
 		color: color-mix(in oklch, currentcolor 50%, transparent);
 	}
 
+	/* A virtual caret: to fix the caret vertical alignment issue in Chrome and Firefox for empty focused contenteditable with placeholders */
+	[placeholder].editable.empty.focused  {
+		caret-color: transparent;
+	}
+	[placeholder].editable.empty.focused::before {
+    content: "";
+		/* we limit width & height to avoid layout shifts in case the text has a lower natural height */
+    width: 0px;
+    height: 1cap;
+    display: inline-block;
+		/* we use box-shadow to draw the caret shape, matching the native caret */
+    box-shadow: 
+			0 -0.4cap 0 0.65px var(--svedit-caret-color, AccentColor),
+			0 0 0 0.65px var(--svedit-caret-color, AccentColor),
+			0 0.4cap 0 0.65px var(--svedit-caret-color, AccentColor);
+		animation: var(
+			--node-caret-animation,
+			node-caret-blink var(--node-caret-blink-duration, 1.1s) ease-in-out infinite
+		);
+	}
+
 	/* Hide flickering: in Chrome, the caret jumps from end of placeholder string to start of text property when we focus */
 	.text:not(.focused) {
 		caret-color: transparent;

--- a/src/lib/AnnotatedTextProperty.svelte
+++ b/src/lib/AnnotatedTextProperty.svelte
@@ -160,8 +160,10 @@
 	}
 
 	/* A virtual caret: to fix the caret vertical alignment issue in Chrome and Firefox for empty focused contenteditable with placeholders */
-	.empty  {
-		caret-color: red !important;
+    /* Browser BUG: iOS Safari only considers the caret color set on the top contenteditable element, not on nested elements (e.g. the second selector doesn't work in iOS Safari) */
+	:global(.svedit-canvas:has([placeholder].editable.empty.focused)), 
+    [placeholder].editable.empty.focused {
+		caret-color: transparent !important;
 	}
 	[placeholder].editable.empty.focused::before {
     content: "";

--- a/src/lib/AnnotatedTextProperty.svelte
+++ b/src/lib/AnnotatedTextProperty.svelte
@@ -161,7 +161,7 @@
 
 	/* A virtual caret: to fix the caret vertical alignment issue in Chrome and Firefox for empty focused contenteditable with placeholders */
 	.empty  {
-		caret-color: transparent;
+		caret-color: red !important;
 	}
 	[placeholder].editable.empty.focused::before {
     content: "";

--- a/src/lib/AnnotatedTextProperty.svelte
+++ b/src/lib/AnnotatedTextProperty.svelte
@@ -160,7 +160,7 @@
 	}
 
 	/* A virtual caret: to fix the caret vertical alignment issue in Chrome and Firefox for empty focused contenteditable with placeholders */
-	[placeholder].editable.empty.focused  {
+	.empty  {
 		caret-color: transparent;
 	}
 	[placeholder].editable.empty.focused::before {

--- a/src/lib/NodeCaret.svelte
+++ b/src/lib/NodeCaret.svelte
@@ -11,13 +11,6 @@
 <div class="caret" role="none"></div>
 
 <style>
-	@keyframes node-caret-blink {
-		0%, 60% { opacity: 1; }
-		68% { opacity: 0; }
-		88% { opacity: 0; }
-		100% { opacity: 1; }
-	}
-
 	.caret {
 		--_R: var(--row, 1);
 		--_C: calc(1 - var(--row, 1));

--- a/src/lib/Svedit.svelte
+++ b/src/lib/Svedit.svelte
@@ -11,6 +11,7 @@
 	import { create_gap_computation } from './node_gap_computation.svelte.js';
 	import DefaultNodeSelectionMarkers from './NodeSelectionMarkers.svelte';
 	import './styles/svedit-colors.css';
+	import './styles/svedit-animations.css';
 
 	/** @import {
 	 *   SveditProps,
@@ -1442,7 +1443,7 @@ ${fallback_html}`;
 
 <style>
 	.svedit-canvas {
-		caret-color: var(--svedit-editing-stroke);
+		caret-color: var(--svedit-caret-color);
 		caret-shape: bar;
 		/* Default to vertical/ column flow with: --row: 0; (the most common case)
 		Prevents silent failures when developers forget to set the row property in their top level node component.

--- a/src/lib/Svedit.svelte
+++ b/src/lib/Svedit.svelte
@@ -8,6 +8,7 @@
 	import { create_gap_computation } from './node_gap_computation.svelte.js';
 	import DefaultNodeSelectionMarkers from './NodeSelectionMarkers.svelte';
 	import './styles/svedit-colors.css';
+	import './styles/svedit-animations.css';
 
 	/** @import {
 	 *   SveditProps,
@@ -1369,7 +1370,7 @@ ${fallback_html}`;
 
 <style>
 	.svedit-canvas {
-		caret-color: var(--svedit-editing-stroke);
+		caret-color: var(--svedit-caret-color);
 		caret-shape: bar;
 		/* Default to vertical/ column flow with: --row: 0; (the most common case)
 		Prevents silent failures when developers forget to set the row property in their top level node component.

--- a/src/lib/styles/svedit-animations.css
+++ b/src/lib/styles/svedit-animations.css
@@ -1,0 +1,8 @@
+@layer svedit-defaults {
+	@keyframes node-caret-blink {
+		0%, 60% { opacity: 1; }
+		68% { opacity: 0; }
+		88% { opacity: 0; }
+		100% { opacity: 1; }
+	}
+}

--- a/src/lib/styles/svedit-colors.css
+++ b/src/lib/styles/svedit-colors.css
@@ -4,5 +4,6 @@
 		--svedit-editing-stroke: var(--svedit-brand);
 		--svedit-editing-fill: oklch(from var(--svedit-brand) l c h / 0.1);
 		--svedit-canvas-stroke: color-mix(in oklch, currentColor 25%, transparent);
+		--svedit-caret-color: var(--svedit-brand);
 	}
 }


### PR DESCRIPTION
## Problem
When focusing an empty text property that has a placeholder, the native caret in Chrome and Firefox is vertically misaligned — it doesn't align with the placeholder text rendered via `::after`.

## Solution
- Hide the native caret on empty focused editable text properties with placeholders
- Render a virtual caret via a `::before` pseudo-element using box-shadow, sized to `1cap` with vertical extensions to match the text line
- Reuses the node caret's blink animation and respects `--svedit-caret-color`

## Test plan
- [x] Focus an empty text property with a placeholder — caret should be vertically aligned with the placeholder text
- [x] Verify on Chrome, Firefox, and Safari

Made with [Cursor](https://cursor.com)