### PR TITLE
Node gaps always present in DOM (viewing and editable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1087,8 +1087,59 @@ Further things to consider:
 - Never apply `position: relative` to the direct parent of `<AnnotatedTextProperty>`, it will cause a [weird Safari bug](https://bsky.app/profile/michaelaufreiter.com/post/3lxvdqyxc622s) to destroy the DOM.
 - Never apply `position: relative`, `position: absolute`, `position: fixed` to `<Node.svelte>` (data-type="node") in edit mode. Only `position: static` is permitted to allow css anchor positioning queries to resolve correctly.
 - Never use an `<a>` tag inside a `contenteditable="true"` element, as it will cause unexpected behavior. Make it a `<div>` while editing, and an `<a>` in read-only mode (when `svedit.editable` is `false` ).
-- Avoid CSS selectors like `:last-child` or `:first-child` on nodes (e.g., `[data-type="node"]:last-child`) because `<NodeGap>` elements are inserted in edit mode and will become the actual first or last child. This can cause unexpected layout shifts (e.g., if you have `.paragraph-node:last-child { margin-bottom: 10px }`, the margin won't apply as expected).
-- Avoid adding css `margin` to nodes inside node arrays when using flex or grid layouts. Use `gap` on the container instead. This ensure `NodeGap` and `NodeGapMarkers` render consistently. If you need to add a margin, add it to child element of Node.
+- Avoid adding css `margin` to nodes inside node arrays when using flex or grid layouts. Use `gap` on the container instead. This ensures `NodeGap` and `NodeGapMarkers` render consistently. If you need to add a margin, add it to a child element of Node.
+
+### Consistent DOM structure across modes
+
+`<NodeArrayProperty>` always renders a `.node-gap` element before each node, regardless of whether the editor is in edit or read-only mode. In edit mode, this is the full `<NodeGap>` component with anchor positioning, hit areas, and caret support. In read-only mode, it's a plain `<div class="node-gap"></div>`.
+
+This means the DOM structure is identical in both modes:
+
+```html
+<!-- Same structure in edit and read-only mode -->
+<div data-type="node_array">
+  <div class="node-gap">...</div><!-- First element is a node-gap -->
+  <div data-type="node"><!-- first node --></div>
+  <div class="node-gap">...</div>
+  <div data-type="node"><!-- second node --></div>
+  ...
+  <div class="node-gap">...</div><!-- Last element is a node-gap -->
+</div>
+```
+
+The `.node-gap` element uses `display: contents`, so it has no layout impact — it doesn't generate a box, doesn't affect flex/grid item counts, and doesn't consume space. It only serves as a DOM placeholder for consistent selector targeting.
+
+Because `.node-gap` is always the actual first and last child, do not use `:first-child` or `:last-child` on nodes — they will never match. Use `:nth-child(1 of [data-type="node"])` and `:nth-last-child(1 of [data-type="node"])` instead.
+
+CSS sibling selectors that target node adjacency only need one form:
+
+```css
+/* Works in both edit and read-only mode */
+.node-text + .node-gap + .node-media {
+  margin-block-start: 1rem;
+}
+```
+
+For `:nth-child` selectors, use the `of <selector>` syntax to skip over `.node-gap` elements and count only nodes:
+
+```css
+/* Even nodes */
+.list-node-array > :nth-child(2n of [data-type="node"]) {
+  background: var(--zebra-stripe);
+}
+
+/* Odd nodes */
+.list-node-array > :nth-child(2n-1 of [data-type="node"]) {
+  background: var(--zebra-stripe);
+}
+
+/* Last node */
+.list-node-array > :nth-last-child(1 of [data-type="node"]) {
+  border-bottom: none;
+}
+```
+
+Without the `of` filter, plain `:nth-child(even)` would count `.node-gap` divs and produce incorrect results. The [`of <selector>`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/:nth-child#syntax) form is Baseline 2023 and supported in all modern browsers.
 
 ### Node array CSS tokens
 

--- a/src/lib/NodeArrayProperty.svelte
+++ b/src/lib/NodeArrayProperty.svelte
@@ -41,41 +41,41 @@
 	data-path={path_str}
 	style="anchor-name: --{path.join('-')};{style ? ` ${style}` : ''}" {...rest}
 >
-	{#if node_ids.length === 0 && svedit.editable}
+	{#if node_ids.length === 0}
 		<!--
-		Experimental: We'll let .empty-node-array act like a node, so the existing
+		Experimental: We'll let .empty-node-placeholder act like a node, so the existing
 		code paths for selection mapping will work as expected.
 
-		TODO: Need to figure out a way to make .empty-node-array customizable.
+		TODO: Need to figure out a way to make .empty-node-placeholder customizable.
 		-->
-		<div
-			class="node empty-node-array"
-			data-path={[...path, 0].join('.')}
-			data-type="node"
-			style="anchor-name: --{[...path, 0].join(
-				'-'
-			)}; min-height: 40px; min-width: 24px;"
-		></div>
-		<!-- Sibling (not child) of .empty-node-array so its .svedit-selectable
-		     resolves anchor positioning against the shared containing block,
-		     not the placeholder which inherits .node positioning styles. -->
+		{#if svedit.editable}
+			<div
+				class="empty-node-placeholder"
+				data-path={[...path, 0].join('.')}
+				data-type="node"
+				style="anchor-name: --{[...path, 0].join(
+					'-'
+				)}; min-height: 40px; min-width: 24px;"
+			></div>
+			<!-- Sibling (not child) of .empty-node-placeholder so its .svedit-selectable
+			     resolves anchor positioning against the shared containing block,
+			     not the placeholder which inherits .node positioning styles. -->
+		{/if}
 		<NodeGap
 			array_path={path}
 			offset={0}
 			count={0}
 			empty
-			positioned={svedit.should_position_gap?.(path_str, 0, 0) ?? true}
+			positioned={svedit.editable ? (svedit.should_position_gap?.(path_str, 0, 0) ?? true) : false}
 		/>
 	{/if}
 	{#each nodes as node, index (index)}
-		{#if svedit.editable}
-			<NodeGap
-				array_path={path}
-				offset={index}
-				count={nodes.length}
-				positioned={svedit.should_position_gap?.(path_str, index, nodes.length) ?? true}
-			/>
-		{/if}
+		<NodeGap
+			array_path={path}
+			offset={index}
+			count={nodes.length}
+			positioned={svedit.editable ? (svedit.should_position_gap?.(path_str, index, nodes.length) ?? true) : false}
+		/>
 		{@const Component = svedit.session.config.node_components[snake_to_pascal(node.type)]}
 		{#if Component}
 			<Component path={[...path, index]} />
@@ -83,12 +83,12 @@
 			<UnknownNode path={[...path, index]} />
 		{/if}
 	{/each}
-	{#if svedit.editable && node_ids.length > 0}
+	{#if node_ids.length > 0}
 		<NodeGap
 			array_path={path}
 			offset={node_ids.length}
 			count={node_ids.length}
-			positioned={svedit.should_position_gap?.(path_str, node_ids.length, node_ids.length) ?? true}
+			positioned={svedit.editable ? (svedit.should_position_gap?.(path_str, node_ids.length, node_ids.length) ?? true) : false}
 		/>
 	{/if}
 	{#if svedit.editable && NodeGapMarkers}

--- a/src/lib/NodeArrayProperty.svelte
+++ b/src/lib/NodeArrayProperty.svelte
@@ -26,8 +26,7 @@
 	// NodeGap while the caret is in the placeholder, so its <br> isn't a
 	// second arrow-key stop (issue #260).
 	let is_focused = $derived(
-		node_ids.length === 0
-		&& svedit.session.selection?.type === 'node'
+		svedit.session.selection?.type === 'node'
 		&& svedit.session.selection.path.join('.') === path_str
 	);
 
@@ -47,6 +46,7 @@
 <svelte:element
 	this={tag}
 	class={css_class}
+	class:focused={is_focused}
 	data-type="node_array"
 	data-path={path_str}
 	style="anchor-name: --{path.join('-')};{style ? ` ${style}` : ''}" {...rest}
@@ -61,7 +61,6 @@
 		{#if svedit.editable}
 			<div
 				class="empty-node-placeholder"
-				class:focused={is_focused}
 				data-path={[...path, 0].join('.')}
 				data-type="node"
 				style="anchor-name: --{[...path, 0].join(
@@ -109,7 +108,7 @@
 
 <style>
 	/* See `is_focused` derived state (issue #260). */
-	:global(.empty-node-placeholder.focused + .node-gap) {
+	:global([data-type='node_array'].focused > .empty-node-placeholder + .node-gap) {
 		display: none;
 	}
 </style>

--- a/src/lib/NodeArrayProperty.svelte
+++ b/src/lib/NodeArrayProperty.svelte
@@ -56,7 +56,7 @@
 				style="anchor-name: --{[...path, 0].join(
 					'-'
 				)}; min-height: 40px; min-width: 24px;"
-			></div>
+			><br /></div>
 			<!-- Sibling (not child) of .empty-node-placeholder so its .svedit-selectable
 			     resolves anchor positioning against the shared containing block,
 			     not the placeholder which inherits .node positioning styles. -->

--- a/src/lib/NodeArrayProperty.svelte
+++ b/src/lib/NodeArrayProperty.svelte
@@ -51,26 +51,15 @@
 	data-path={path_str}
 	style="anchor-name: --{path.join('-')};{style ? ` ${style}` : ''}" {...rest}
 >
-	{#if node_ids.length === 0}
-		<!--
-		Experimental: We'll let .empty-node-placeholder act like a node, so the existing
-		code paths for selection mapping will work as expected.
-
-		TODO: Need to figure out a way to make .empty-node-placeholder customizable.
-		-->
-		{#if svedit.editable}
-			<div
-				class="empty-node-placeholder"
-				data-path={[...path, 0].join('.')}
-				data-type="node"
-				style="anchor-name: --{[...path, 0].join(
-					'-'
-				)}; min-height: 40px; min-width: 24px;"
-			><br /></div>
-			<!-- Sibling (not child) of .empty-node-placeholder so its .svedit-selectable
-			     resolves anchor positioning against the shared containing block,
-			     not the placeholder which inherits .node positioning styles. -->
-		{/if}
+	{#if node_ids.length === 0 && svedit.editable}
+		<div
+			class="empty-node-placeholder"
+			data-path={[...path, 0].join('.')}
+			data-type="node"
+			style="anchor-name: --{[...path, 0].join(
+				'-'
+			)}; --node-array-anchor: --{path.join('-')}"
+		>
 		<NodeGap
 			array_path={path}
 			offset={0}
@@ -78,6 +67,7 @@
 			empty
 			positioned={svedit.editable ? (svedit.should_position_gap?.(path_str, 0, 0) ?? true) : false}
 		/>
+		</div>
 	{/if}
 	{#each nodes as node, index (index)}
 		<NodeGap
@@ -107,8 +97,11 @@
 </svelte:element>
 
 <style>
-	/* See `is_focused` derived state (issue #260). */
-	:global([data-type='node_array'].focused > .empty-node-placeholder + .node-gap) {
-		display: none;
-	}
+.empty-node-placeholder {
+	cursor: pointer;
+	right: anchor(var(--node-array-anchor) right);
+	left: anchor(var(--node-array-anchor) left);
+	min-height: 40px; 
+	min-width: 24px; 
+}
 </style>

--- a/src/lib/NodeArrayProperty.svelte
+++ b/src/lib/NodeArrayProperty.svelte
@@ -21,10 +21,11 @@
 	let node_ids = $derived(svedit.session.get(path));
 	let nodes = $derived(node_ids.map(id => svedit.session.get(id)));
 
-	// Empty arrays render both an .empty-node-placeholder (cursor target) and
-	// a NodeGap (wide click hit area). Hide the gap while the caret is in the
-	// placeholder so its <br> isn't a second arrow-key stop (issue #260).
-	let cursor_in_empty_placeholder = $derived(
+	// Mirrors the AnnotatedTextProperty pattern: a `focused` class follows
+	// the model selection. Used by the CSS rule below to hide the empty-array
+	// NodeGap while the caret is in the placeholder, so its <br> isn't a
+	// second arrow-key stop (issue #260).
+	let is_focused = $derived(
 		node_ids.length === 0
 		&& svedit.session.selection?.type === 'node'
 		&& svedit.session.selection.path.join('.') === path_str
@@ -60,7 +61,7 @@
 		{#if svedit.editable}
 			<div
 				class="empty-node-placeholder"
-				class:cursor-here={cursor_in_empty_placeholder}
+				class:focused={is_focused}
 				data-path={[...path, 0].join('.')}
 				data-type="node"
 				style="anchor-name: --{[...path, 0].join(
@@ -107,8 +108,8 @@
 </svelte:element>
 
 <style>
-	/* See `cursor_in_empty_placeholder` derived state (issue #260). */
-	:global(.empty-node-placeholder.cursor-here + .node-gap) {
+	/* See `is_focused` derived state (issue #260). */
+	:global(.empty-node-placeholder.focused + .node-gap) {
 		display: none;
 	}
 </style>

--- a/src/lib/NodeArrayProperty.svelte
+++ b/src/lib/NodeArrayProperty.svelte
@@ -21,6 +21,15 @@
 	let node_ids = $derived(svedit.session.get(path));
 	let nodes = $derived(node_ids.map(id => svedit.session.get(id)));
 
+	// Empty arrays render both an .empty-node-placeholder (cursor target) and
+	// a NodeGap (wide click hit area). Hide the gap while the caret is in the
+	// placeholder so its <br> isn't a second arrow-key stop (issue #260).
+	let cursor_in_empty_placeholder = $derived(
+		node_ids.length === 0
+		&& svedit.session.selection?.type === 'node'
+		&& svedit.session.selection.path.join('.') === path_str
+	);
+
 	setContext('node_array_meta', {
 		get length() { return node_ids.length; }
 	});
@@ -51,6 +60,7 @@
 		{#if svedit.editable}
 			<div
 				class="empty-node-placeholder"
+				class:cursor-here={cursor_in_empty_placeholder}
 				data-path={[...path, 0].join('.')}
 				data-type="node"
 				style="anchor-name: --{[...path, 0].join(
@@ -95,3 +105,10 @@
 		<NodeGapMarkers {path} />
 	{/if}
 </svelte:element>
+
+<style>
+	/* See `cursor_in_empty_placeholder` derived state (issue #260). */
+	:global(.empty-node-placeholder.cursor-here + .node-gap) {
+		display: none;
+	}
+</style>

--- a/src/lib/NodeGap.svelte
+++ b/src/lib/NodeGap.svelte
@@ -77,7 +77,21 @@
 		data-gap-offset={offset}
 		style={gap_style}
 	>
-		<div class="svedit-selectable" style="anchor-name:{anchor_name}"><br /></div>
+		<!-- For empty arrays the .svedit-selectable is the wide click hit area
+		     only — the cursor stop lives in the sibling .empty-node-placeholder's
+		     <br>. contenteditable=false stops it from becoming a second arrow-key
+		     stop; the click handler routes clicks to the placeholder since
+		     contenteditable=false elements swallow native cursor placement. -->
+		<div
+			class="svedit-selectable"
+			style="anchor-name:{anchor_name}"
+			contenteditable={empty ? 'false' : undefined}
+			onpointerdown={empty ? (e) => {
+				e.preventDefault();
+				const ph = e.currentTarget.closest('.node-gap')?.previousElementSibling;
+				if (ph) window.getSelection().setBaseAndExtent(ph, 0, ph, 0);
+			} : undefined}
+		>{#if !empty}<br />{/if}</div>
 	</div>
 {:else}
 	<div class="node-gap"></div>

--- a/src/lib/NodeGap.svelte
+++ b/src/lib/NodeGap.svelte
@@ -1,4 +1,6 @@
 <script>
+	import { getContext } from 'svelte';
+
 	/**
 	 * ┌─────────────────────────────────────────────────────────────────┐
 	 * │ MUST RULES — do not violate when modifying this file            │
@@ -33,14 +35,21 @@
 	 *
 	 * Row/column detection uses var(--row, 1) with the * 99999 multiplier
 	 * trick — no @container style() queries, works in all browsers.
+	 *
+	 * If you override this component via `system_components.NodeGap`, make
+	 * sure your custom component also handles read-only mode by rendering a
+	 * plain `.node-gap` placeholder without editable internals.
 	 */
+	const svedit = getContext('svedit');
 	let { array_path, offset, count, empty = false, positioned = true } = $props();
+	let is_editable = $derived(svedit.editable);
 
 	let is_first = $derived(offset === 0);
 	let is_last = $derived(offset === count);
 	let type = $derived(is_first ? 'gap-before' : 'gap-after');
 
 	let gap_style = $derived.by(() => {
+		if (!is_editable) return '';
 		const arr = array_path.join('-');
 		const prev_idx = offset - 1;
 		const pa = is_first ? `--${arr}-0` : `--${arr}-${prev_idx}`;
@@ -50,24 +59,29 @@
 	});
 
 	let anchor_name = $derived.by(() => {
+		if (!is_editable) return '';
 		const arr = array_path.join('-');
 		if (is_first) return `--g-${arr}-0-gap-before`;
 		return `--g-${arr}-${offset - 1}-gap-after`;
 	});
 </script>
 
-<div
-	class="node-gap {type}"
-	class:empty
-	class:last={is_last}
-	class:positioned
-	data-type={type}
-	data-gap-array-path={array_path.join('.')}
-	data-gap-offset={offset}
-	style={gap_style}
->
-	<div class="svedit-selectable" style="anchor-name:{anchor_name}"><br /></div>
-</div>
+{#if is_editable}
+	<div
+		class="node-gap {type}"
+		class:empty
+		class:last={is_last}
+		class:positioned
+		data-type={type}
+		data-gap-array-path={array_path.join('.')}
+		data-gap-offset={offset}
+		style={gap_style}
+	>
+		<div class="svedit-selectable" style="anchor-name:{anchor_name}"><br /></div>
+	</div>
+{:else}
+	<div class="node-gap"></div>
+{/if}
 
 
 <style>

--- a/src/lib/NodeGap.svelte
+++ b/src/lib/NodeGap.svelte
@@ -77,21 +77,7 @@
 		data-gap-offset={offset}
 		style={gap_style}
 	>
-		<!-- For empty arrays the .svedit-selectable is the wide click hit area
-		     only — the cursor stop lives in the sibling .empty-node-placeholder's
-		     <br>. contenteditable=false stops it from becoming a second arrow-key
-		     stop; the click handler routes clicks to the placeholder since
-		     contenteditable=false elements swallow native cursor placement. -->
-		<div
-			class="svedit-selectable"
-			style="anchor-name:{anchor_name}"
-			contenteditable={empty ? 'false' : undefined}
-			onpointerdown={empty ? (e) => {
-				e.preventDefault();
-				const ph = e.currentTarget.closest('.node-gap')?.previousElementSibling;
-				if (ph) window.getSelection().setBaseAndExtent(ph, 0, ph, 0);
-			} : undefined}
-		>{#if !empty}<br />{/if}</div>
+		<div class="svedit-selectable" style="anchor-name:{anchor_name}"><br /></div>
 	</div>
 {:else}
 	<div class="node-gap"></div>

--- a/src/lib/Svedit.svelte
+++ b/src/lib/Svedit.svelte
@@ -883,15 +883,13 @@ ${fallback_html}`;
 
 		// Check if it's a backwards selection
 		const is_backwards = __is_dom_selection_backwards();
-		// The +1 converts "cursor on node N" → "selection ends after node N"
-		// (offset N+1). Skip for empty arrays where the .empty-node-placeholder
-		// is at path-index 0 but the only valid offset is 0.
-		if (session.get(parent_array_path)?.length > 0) {
-			if (is_backwards) {
-				anchor_offset += 1;
-			} else {
-				focus_offset += 1;
-			}
+		// Skip the "cursor on node N" → "ends after N" bump for empty arrays:
+		// the .empty-node-placeholder sits at path-index 0 but offset 0 is the
+		// only valid offset (would otherwise validate as out-of-bounds 1).
+		const is_empty_array = session.get(parent_array_path)?.length === 0;
+		if (!is_empty_array) {
+			if (is_backwards) anchor_offset += 1;
+			else focus_offset += 1;
 		}
 
 		// EDGE CASE: Exclude first node when anchor_node is a gap-after
@@ -1118,30 +1116,17 @@ ${fallback_html}`;
 			`[data-gap-array-path="${node_array_path}"][data-gap-offset="${offset}"]`;
 
 		if (is_collapsed) {
-			// Empty arrays: cursor lives in the .empty-node-placeholder's <br>,
-			// not the gap's .svedit-selectable (which is contenteditable=false
-			// and would strand the caret).
-			const empty_placeholder = node_array_el.querySelector(
-				`:scope > .empty-node-placeholder[data-path="${node_array_path}.0"]`
-			);
-			if (empty_placeholder) {
-				range.setStart(empty_placeholder, 0);
-				range.setEnd(empty_placeholder, 0);
-				dom_selection.removeAllRanges();
-				dom_selection.addRange(range);
-			} else {
-				const gap_el = node_array_el.querySelector(gap_selector(selection.anchor_offset));
-				if (!gap_el) return;
-				// Target .svedit-selectable (has a box), not gap_el which is
-				// display:contents and would cause the browser to normalize
-				// the range into the parent, breaking read-back.
-				const selectable = gap_el.querySelector('.svedit-selectable');
-				if (!selectable) return;
-				range.setStart(selectable, 1);
-				range.setEnd(selectable, 1);
-				dom_selection.removeAllRanges();
-				dom_selection.addRange(range);
-			}
+			const gap_el = node_array_el.querySelector(gap_selector(selection.anchor_offset));
+			if (!gap_el) return;
+			// Target .svedit-selectable (has a box), not gap_el which is
+			// display:contents and would cause the browser to normalize
+			// the range into the parent, breaking read-back.
+			const selectable = gap_el.querySelector('.svedit-selectable');
+			if (!selectable) return;
+			range.setStart(selectable, 1);
+			range.setEnd(selectable, 1);
+			dom_selection.removeAllRanges();
+			dom_selection.addRange(range);
 		} else {
 			const anchor_gap = node_array_el.querySelector(gap_selector(selection.anchor_offset));
 			const focus_gap = node_array_el.querySelector(gap_selector(selection.focus_offset));

--- a/src/lib/Svedit.svelte
+++ b/src/lib/Svedit.svelte
@@ -883,10 +883,15 @@ ${fallback_html}`;
 
 		// Check if it's a backwards selection
 		const is_backwards = __is_dom_selection_backwards();
-		if (is_backwards) {
-			anchor_offset += 1;
-		} else {
-			focus_offset += 1;
+		// The +1 converts "cursor on node N" → "selection ends after node N"
+		// (offset N+1). Skip for empty arrays where the .empty-node-placeholder
+		// is at path-index 0 but the only valid offset is 0.
+		if (session.get(parent_array_path)?.length > 0) {
+			if (is_backwards) {
+				anchor_offset += 1;
+			} else {
+				focus_offset += 1;
+			}
 		}
 
 		// EDGE CASE: Exclude first node when anchor_node is a gap-after
@@ -1113,17 +1118,30 @@ ${fallback_html}`;
 			`[data-gap-array-path="${node_array_path}"][data-gap-offset="${offset}"]`;
 
 		if (is_collapsed) {
-			const gap_el = node_array_el.querySelector(gap_selector(selection.anchor_offset));
-			if (!gap_el) return;
-			// Target .svedit-selectable (has a box), not gap_el which is
-			// display:contents and would cause the browser to normalize
-			// the range into the parent, breaking read-back.
-			const selectable = gap_el.querySelector('.svedit-selectable');
-			if (!selectable) return;
-			range.setStart(selectable, 1);
-			range.setEnd(selectable, 1);
-			dom_selection.removeAllRanges();
-			dom_selection.addRange(range);
+			// Empty arrays: cursor lives in the .empty-node-placeholder's <br>,
+			// not the gap's .svedit-selectable (which is contenteditable=false
+			// and would strand the caret).
+			const empty_placeholder = node_array_el.querySelector(
+				`:scope > .empty-node-placeholder[data-path="${node_array_path}.0"]`
+			);
+			if (empty_placeholder) {
+				range.setStart(empty_placeholder, 0);
+				range.setEnd(empty_placeholder, 0);
+				dom_selection.removeAllRanges();
+				dom_selection.addRange(range);
+			} else {
+				const gap_el = node_array_el.querySelector(gap_selector(selection.anchor_offset));
+				if (!gap_el) return;
+				// Target .svedit-selectable (has a box), not gap_el which is
+				// display:contents and would cause the browser to normalize
+				// the range into the parent, breaking read-back.
+				const selectable = gap_el.querySelector('.svedit-selectable');
+				if (!selectable) return;
+				range.setStart(selectable, 1);
+				range.setEnd(selectable, 1);
+				dom_selection.removeAllRanges();
+				dom_selection.addRange(range);
+			}
 		} else {
 			const anchor_gap = node_array_el.querySelector(gap_selector(selection.anchor_offset));
 			const focus_gap = node_array_el.querySelector(gap_selector(selection.focus_offset));

--- a/src/lib/Svedit.svelte
+++ b/src/lib/Svedit.svelte
@@ -883,14 +883,8 @@ ${fallback_html}`;
 
 		// Check if it's a backwards selection
 		const is_backwards = __is_dom_selection_backwards();
-		// Skip the "cursor on node N" → "ends after N" bump for empty arrays:
-		// the .empty-node-placeholder sits at path-index 0 but offset 0 is the
-		// only valid offset (would otherwise validate as out-of-bounds 1).
-		const is_empty_array = session.get(parent_array_path)?.length === 0;
-		if (!is_empty_array) {
-			if (is_backwards) anchor_offset += 1;
-			else focus_offset += 1;
-		}
+		if (is_backwards) anchor_offset += 1;
+		else focus_offset += 1;
 
 		// EDGE CASE: Exclude first node when anchor_node is a gap-after
 		// in a non-collapsed forward selection.

--- a/src/lib/node_gap_computation.svelte.js
+++ b/src/lib/node_gap_computation.svelte.js
@@ -702,7 +702,7 @@ export function create_gap_computation(svedit) {
 
 		// Build culled gaps uniformly for every array that has visible
 		// children (root-level and nested alike). Empty arrays are covered
-		// because NodeArrayProperty renders an `.empty-node-array`
+		// because NodeArrayProperty renders an `.empty-node-placeholder`
 		// placeholder with `data-type="node"`, which IO observes like any
 		// other node — when visible, the array appears in index_map with
 		// child_index 0, and `build_array_gaps_culled` dispatches to the

--- a/src/routes/components/List.svelte
+++ b/src/routes/components/List.svelte
@@ -20,4 +20,8 @@
 		flex-direction: column;
 		gap: var(--s-4);
 	}
+	/* Use `of [data-type="node"]` to skip interleaved .node-gap elements */
+	.list :global(.list-node-array > :nth-child(2n of [data-type="node"]) .list-item) {
+		background: color-mix(in oklab, var(--app-primary-fill) 5%, transparent);
+	}
 </style>

--- a/src/routes/components/Story.svelte
+++ b/src/routes/components/Story.svelte
@@ -72,7 +72,7 @@
 		}
 	}
 
-	.story :global(.buttons.empty .node.empty-node-array) {
+	.story :global(.buttons.empty .empty-node-placeholder) {
 		position: absolute !important;
 	}
 


### PR DESCRIPTION
with documentation and example in List component for new css selectors;

Potentially breaking rename:
"empty-node-array" → "empty-node-placeholder"

Fixes this issue:
https://github.com/michael/svedit/issues/251#issuecomment-4356400668