### PR TITLE
Make Transaction.set ref-count-aware when cleaning up removed nodes

### DIFF
--- a/src/lib/Transaction.svelte.js
+++ b/src/lib/Transaction.svelte.js
@@ -223,9 +223,15 @@ export default class Transaction {
 		this.inverse_ops.push(['set', normalized_path, previous_value]);
 		this._apply_op(op);
 
-		for (const removed_node_id of removed_node_ids) {
-			// NOTE: This implicitly deletes childnodes as well, given that they are no longer referenced.
-			this.delete(removed_node_id);
+		// Garbage-collect nodes whose only reference was via this property.
+		// We must use a ref-count-aware sweep instead of unconditional deletion
+		// because a node ID removed from this array may still be referenced
+		// elsewhere — either from a pre-existing reference (e.g. shared nodes)
+		// or from a node created earlier in the same transaction (the
+		// wrap-in-group pattern: create a wrapper that points at the children,
+		// then set the parent array to drop them).
+		if (removed_node_ids.length > 0) {
+			this._cascade_delete_unreferenced_nodes(removed_node_ids);
 		}
 
 		return this;
@@ -328,6 +334,13 @@ export default class Transaction {
 	 * Deletes a node from the document by its ID.
 	 *
 	 * The node's current state is captured for undo support before deletion.
+	 *
+	 * NOTE: This is a force-delete and intentionally does NOT check whether
+	 * the node is still referenced from elsewhere — callers (e.g.
+	 * `annotate_text`) sometimes need to remove a node while a stale
+	 * reference to it still exists in the property they are about to update.
+	 * For ref-count-aware cleanup, see how `set` calls
+	 * `_cascade_delete_unreferenced_nodes`.
 	 *
 	 * @param {any} id - The ID of the node to delete
 	 * @returns {Transaction} This transaction instance for method chaining

--- a/src/test/Session.svelte.test.js
+++ b/src/test/Session.svelte.test.js
@@ -262,6 +262,68 @@ describe('Session.svelte.js', () => {
 			expect(session.get('list_1').list_items).toEqual(['list_item_1', 'list_item_2']);
 		});
 
+		it('should preserve a node that is moved into a wrapper created earlier in the same transaction', () => {
+			// Reproduces the wrap-in-group pattern that is used by editors
+			// built on Svedit (e.g. interface-lineage):
+			//   1. tr.create({ id: wrapper, ..., children: [a, b] })
+			//   2. tr.set([parent, children_property], [...without a and b])
+			//
+			// At step (2) the IDs `a` and `b` no longer appear in the parent's
+			// array, so set()'s naive "removed = previous − new" sweep would
+			// flag them for deletion. They must NOT be deleted because the
+			// wrapper created in step (1) still references them.
+			const session = create_test_session();
+
+			expect(session.get(['list_1', 'list_items'])).toEqual(['list_item_1', 'list_item_2']);
+
+			const tr = session.tr;
+
+			// Step (1): create a new list that already references list_item_1.
+			// After this, list_item_1 is referenced from BOTH list_1 and list_2.
+			tr.create({
+				id: 'list_2',
+				type: 'list',
+				layout: 1,
+				list_items: ['list_item_1']
+			});
+
+			// Step (2): drop list_item_1 from list_1.list_items. The set()
+			// call would compute removed_node_ids = ['list_item_1'], but the
+			// node is still referenced by list_2 and must survive.
+			tr.set(['list_1', 'list_items'], ['list_item_2']);
+
+			session.apply(tr);
+
+			expect(session.get(['list_1', 'list_items'])).toEqual(['list_item_2']);
+			expect(session.get(['list_2', 'list_items'])).toEqual(['list_item_1']);
+			expect(session.get('list_item_1')).toBeDefined();
+		});
+
+		it('should restore both source and destination arrays when a wrap-style move is undone', () => {
+			const session = create_test_session();
+
+			const tr = session.tr;
+			tr.create({
+				id: 'list_2',
+				type: 'list',
+				layout: 1,
+				list_items: ['list_item_1']
+			});
+			tr.set(['list_1', 'list_items'], ['list_item_2']);
+			session.apply(tr);
+
+			// Sanity-check the post-state before undoing.
+			expect(session.get(['list_1', 'list_items'])).toEqual(['list_item_2']);
+			expect(session.get('list_2')).toBeDefined();
+
+			session.undo();
+
+			expect(session.get(['list_1', 'list_items'])).toEqual(['list_item_1', 'list_item_2']);
+			expect(session.get('list_2')).toBeUndefined();
+			expect(session.get('list_item_1')).toBeDefined();
+			expect(session.get('list_item_2')).toBeDefined();
+		});
+
 		it('should handle complex nested deletion scenarios', () => {
 			const session = create_test_session();
 


### PR DESCRIPTION
Transaction.set previously called this.delete() unconditionally for any node ID that was present in the property's previous value but not in the new value. This is wrong whenever the removed ID is still reachable from elsewhere in the document — most notably when a single transaction creates a wrapper that references the children before setting the parent array to drop them (the "wrap-in-group" pattern used by editors built on Svedit, e.g. interface-lineage's WrapInGroupCommand). The unconditional delete force-destroys the children and leaves the wrapper dangling.

Replace the loop with a call to the existing _cascade_delete_unreferenced_nodes helper, which only deletes nodes whose reference count has dropped to zero. Document the asymmetry on delete() — it stays a force-delete on purpose, because annotate_text and other callers need to remove a node while a stale reference still exists in the property they are about to update.

Tests: add two cases to the Deletion scenarios suite covering the forward wrap-style move and its undo.