### PR TITLE
Break text on block

### DIFF
--- a/src/lib/Svedit.svelte
+++ b/src/lib/Svedit.svelte
@@ -1534,7 +1534,7 @@ ${fallback_html}`;
 
 	@media not (pointer: coarse) {
 		@supports (anchor-name: --test) {
-			:where(.svedit-canvas.hide-selection) :global(::selection) {
+			.svedit-canvas.hide-selection :global(::selection) {
 				background: transparent;
 			}
 		}

--- a/src/lib/transforms.svelte.js
+++ b/src/lib/transforms.svelte.js
@@ -20,16 +20,39 @@ export function break_text_node(tr) {
 	// First we need to ensure we have a text selection
 	if (selection.type !== 'text') return false;
 
-	// Next, we need to determine if the enclosing node is a pure text node (e.g. paragraph),
-	// which is wrapped inside a node_array (e.g. page.body)
+	// Next, we need to determine if the enclosing node is a pure text node
+	// (e.g. paragraph) OR a single-text-field block node (e.g. button),
+	// which is wrapped inside a node_array.
 
-	// Owner of the text property (e.g. paragraph)
+	// Owner of the text property (e.g. paragraph or button)
 	const node = tr.get(selection.path.slice(0, -1));
-	if (tr.kind(node) !== 'text') return false;
+	const kind = tr.kind(node);
+	const text_prop = selection.path.at(-1);
+
+	// Determine which text property holds the content to split. For a
+	// 'text' kind node it's always 'content'. For a 'block' kind node
+	// we only proceed when this is the node's SOLE text-shaped property
+	// (annotated_text / text). Multi-text-field blocks (story, hero)
+	// stay caret-at-gap — the user picks which field by gap selection,
+	// per the project rule.
+	if (kind === 'text') {
+		// existing behaviour
+	} else if (kind === 'block') {
+		const node_schema = tr.schema[node.type];
+		if (!node_schema?.properties) return false;
+		const text_props = Object.entries(node_schema.properties).filter(
+			([_, def]) => def.type === 'annotated_text' || def.type === 'text'
+		);
+		if (text_props.length !== 1) return false;
+		if (text_props[0][0] !== text_prop) return false;
+	} else {
+		return false;
+	}
+
 	const is_inside_node_array = tr.inspect(selection.path.slice(0, -2))?.type === 'node_array';
 	if (!is_inside_node_array) return false; // Do nothing if we're not inside a node_array
 	const node_array_prop = selection.path.at(-3);
-	// Get the node that owns the node_array property (e.g. a page.body)
+	// Get the node that owns the node_array property (e.g. a page.body or a story)
 	const node_array_node = tr.get(selection.path.slice(0, -3));
 
 
@@ -42,7 +65,7 @@ export function break_text_node(tr) {
 	const content = tr.get(selection.path);
 	const [left_text, right_text] = split_annotated_text(content, split_at_position);
 
-	tr.set([node.id, 'content'], left_text);
+	tr.set([node.id, text_prop], left_text);
 
 	const node_insert_position = {
 		type: 'node',

--- a/src/routes/create_demo_session.js
+++ b/src/routes/create_demo_session.js
@@ -740,11 +740,11 @@ export const session_config = {
 				focus_offset: tr.selection.focus_offset
 			});
 		},
-		button: function (tr) {
+		button: function (tr, label_content) {
 			const new_button = {
 				id: nanoid(),
 				type: 'button',
-				label: { text: '', annotations: [] },
+				label: label_content || { text: '', annotations: [] },
 				href: 'https://editable.website'
 			};
 			tr.create(new_button);

--- a/src/routes/create_demo_session.js
+++ b/src/routes/create_demo_session.js
@@ -750,10 +750,10 @@ export const session_config = {
 			tr.create(new_button);
 			tr.insert_nodes([new_button.id]);
 			tr.set_selection({
-				type: 'node',
-				path: [...tr.selection.path],
-				anchor_offset: tr.selection.focus_offset,
-				focus_offset: tr.selection.focus_offset
+				type: 'text',
+				path: [...tr.selection.path, tr.selection.focus_offset - 1, 'label'],
+				anchor_offset: 0,
+				focus_offset: 0
 			});
 		},
 		hero: function (tr) {

--- a/src/test/create_test_session.js
+++ b/src/test/create_test_session.js
@@ -137,11 +137,11 @@ const session_config = {
 		list_item: 1
 	},
 	inserters: {
-		button: function (tr) {
+		button: function (tr, label_content) {
 			const new_button = {
 				id: nanoid(),
 				type: 'button',
-				label: { text: '', annotations: [] },
+				label: label_content || { text: '', annotations: [] },
 				href: 'https://editable.website'
 			};
 			tr.create(new_button);

--- a/src/test/selection_scroll.svelte.test.js
+++ b/src/test/selection_scroll.svelte.test.js
@@ -34,6 +34,7 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { render } from 'vitest-browser-svelte';
+import { break_text_node, insert_default_node } from '../lib/transforms.svelte.js';
 import SveditTest from './testing_components/SveditTest.svelte';
 import {
 	settle,
@@ -61,6 +62,20 @@ function delete_selection(session) {
 	const tr = session.tr;
 	tr.delete_selection();
 	session.apply(tr);
+}
+
+/** Apply the Enter-key behaviour from the demo keymap:
+ * try break_text_node first, fall back to insert_default_node. */
+function press_enter(session) {
+	const tr = session.tr;
+	if (break_text_node(tr)) {
+		session.apply(tr);
+		return;
+	}
+	const tr2 = session.tr;
+	if (insert_default_node(tr2)) {
+		session.apply(tr2);
+	}
 }
 
 describe('node-selection scroll-into-view (row buttons array)', () => {
@@ -290,5 +305,81 @@ describe('node-selection: DOM-driven vs. model-driven', () => {
 		// Model-driven (inserter) → render runs → array rescrolls to
 		// new max → new node + trailing cursor visible.
 		expect(arr.scrollLeft).toBeGreaterThan(scroll_before);
+	});
+});
+
+describe('break_text_node on single-text-field block (button)', () => {
+	it('Enter at the end of a button label creates a new empty button after it', async () => {
+		const session = make_story_session(3);
+		const { container } = render(SveditTest, { session });
+		await settle();
+
+		// Caret at the end of button 1's label ("Action 2")
+		const target_index = 1;
+		const label_text = session.doc.nodes[`btn_${target_index}`].label.text;
+		const canvas = container.querySelector('.svedit-canvas');
+		canvas.focus();
+		session.selection = {
+			type: 'text',
+			path: ['page_1', 'body', 0, 'buttons', target_index, 'label'],
+			anchor_offset: label_text.length,
+			focus_offset: label_text.length
+		};
+		await settle();
+
+		const count_before = session.doc.nodes.story_1.buttons.length;
+		press_enter(session);
+		await settle();
+
+		// Array grew by one
+		expect(session.doc.nodes.story_1.buttons.length).toBe(count_before + 1);
+
+		// New button is at offset target_index + 1, has an empty label
+		// (cursor was at the END so right_text is empty).
+		const new_btn_id = session.doc.nodes.story_1.buttons[target_index + 1];
+		const new_btn = session.doc.nodes[new_btn_id];
+		expect(new_btn.type).toBe('button');
+		expect(new_btn.label.text).toBe('');
+
+		// The original button still has its original label intact.
+		const orig_btn = session.doc.nodes[`btn_${target_index}`];
+		expect(orig_btn.label.text).toBe(label_text);
+
+		// Caret is now inside the new button's label at offset 0.
+		const sel = session.selection;
+		expect(sel.type).toBe('text');
+		expect(sel.path[sel.path.length - 1]).toBe('label');
+		expect(sel.path[sel.path.length - 2]).toBe(target_index + 1);
+		expect(sel.anchor_offset).toBe(0);
+	});
+
+	it('Enter in the MIDDLE of a button label splits text into left/right buttons', async () => {
+		const session = make_story_session(3);
+		const { container } = render(SveditTest, { session });
+		await settle();
+
+		// Caret mid-label of button 1: "Action 2" → split at offset 6
+		// ("Action") so left = "Action", right = " 2".
+		const target_index = 1;
+		const split_at = 6;
+		const canvas = container.querySelector('.svedit-canvas');
+		canvas.focus();
+		session.selection = {
+			type: 'text',
+			path: ['page_1', 'body', 0, 'buttons', target_index, 'label'],
+			anchor_offset: split_at,
+			focus_offset: split_at
+		};
+		await settle();
+
+		press_enter(session);
+		await settle();
+
+		const orig_btn = session.doc.nodes[`btn_${target_index}`];
+		expect(orig_btn.label.text).toBe('Action');
+
+		const new_btn_id = session.doc.nodes.story_1.buttons[target_index + 1];
+		const new_btn = session.doc.nodes[new_btn_id];
+		expect(new_btn.label.text).toBe(' 2');
 	});
 });


### PR DESCRIPTION
New behaviour: 
Determine which text property holds the content to split. For a 'text' kind node it's always 'content'. For a 'block' kind node we only proceed when this is the node's **SOLE** text-shaped property (annotated_text / text). Multi-text-field blocks (story, hero) stay caret-at-gap. So a button in a buttons array behaves the same as a paragraph in the body array:

The dominant intention of a user is to create a button and then change the label / add a link.

Previously it would focus the node gap afterwards, so an extra arrow key back stroke was necessary to focus the button content. Also previously pessing enter inside a button didn't do anything. now it also create a new button node afterwards. consistent behaviour with paragraph.