### PR TITLE
Text behavior for buttons

### DIFF
--- a/src/lib/Svedit.svelte
+++ b/src/lib/Svedit.svelte
@@ -1534,7 +1534,7 @@ ${fallback_html}`;
 
 	@media not (pointer: coarse) {
 		@supports (anchor-name: --test) {
-			:where(.svedit-canvas.hide-selection) :global(::selection) {
+			.svedit-canvas.hide-selection :global(::selection) {
 				background: transparent;
 			}
 		}

--- a/src/lib/doc_utils.js
+++ b/src/lib/doc_utils.js
@@ -4,7 +4,7 @@
  * These functions operate on the core document state (schema, doc, selection, config)
  * without any history management or transaction tracking.
  *
- * @import { NodeId, DocumentPath, PrimitiveType, NodeProperty, NodeArrayProperty, NodeSchema, DocumentSchema, Selection, Annotation, Document, AnnotatedTextProperty, AnnotatedText } from './types'
+ * @import { NodeId, DocumentPath, PrimitiveType, NodeProperty, NodeArrayProperty, NodeSchema, DocumentSchema, Selection, Annotation, Document, AnnotatedTextProperty, AnnotatedText, ValidateDocumentSchema } from './types'
  */
 
 import {
@@ -20,7 +20,7 @@ import {
  * Similar to your define_schema pattern but for document schemas.
  *
  * @template {Record<string, NodeSchema>} S
- * @param {S} schema - The document schema to validate
+ * @param {S & ValidateDocumentSchema<S>} schema - The document schema to validate
  * @returns {S} The same schema, but with type information preserved
  */
 export function define_document_schema(schema) {

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -274,13 +274,51 @@ export type PropertyDefinition =
 export type NodeKind = 'document' | 'block' | 'text' | 'annotation';
 
 /**
- * Schema for text nodes - must have a content property of type annotated_text
+ * Schema for text nodes - must have a content property of type annotated_text.
+ * Use define_document_schema to also check that content is the only annotated_text property.
  */
 export type TextNodeSchema = {
 	kind: 'text';
 	properties: {
 		content: AnnotatedTextProperty;
 	} & Record<string, PropertyDefinition>;
+};
+
+export type AnnotatedTextPropertyNames<Properties> = {
+	[PropertyName in keyof Properties]: Properties[PropertyName] extends { type: 'annotated_text' }
+		? PropertyName
+		: never;
+}[keyof Properties];
+
+export type TextNodeSchemaError<Message extends string> = {
+	[SchemaError in `Svedit schema error: ${Message}`]: never;
+};
+
+export type TextNodeMissingContentError = TextNodeSchemaError<
+	'Text node schemas must define a "content" property of type annotated_text.'
+>;
+
+export type TextNodeExtraAnnotatedTextError<ExtraProperty extends string> = TextNodeSchemaError<
+	`Text node schemas must not define annotated_text property "${ExtraProperty}". Use "content" as the only annotated_text property.`
+>;
+
+export type ValidateTextNodeSchema<Schema> = Schema extends {
+	kind: 'text';
+	properties: infer Properties;
+}
+	? string extends keyof Properties
+		? Schema
+		: Properties extends { content: AnnotatedTextProperty }
+			? Exclude<AnnotatedTextPropertyNames<Properties>, 'content'> extends infer ExtraProperties
+				? [ExtraProperties] extends [never]
+					? Schema
+					: TextNodeExtraAnnotatedTextError<Extract<ExtraProperties, string>>
+				: never
+			: TextNodeMissingContentError
+	: Schema;
+
+export type ValidateDocumentSchema<Schema extends Record<string, NodeSchema>> = {
+	[NodeType in keyof Schema]: ValidateTextNodeSchema<Schema[NodeType]>;
 };
 
 /**

--- a/src/routes/components/Button.svelte
+++ b/src/routes/components/Button.svelte
@@ -13,7 +13,7 @@
 		href={svedit.editable ? undefined : node.href}
 		class="button"
 	>
-		<AnnotatedTextProperty class="body" path={[...path, 'label']} placeholder="Call to Action" />
+		<AnnotatedTextProperty class="body" path={[...path, 'content']} placeholder="Call to Action" />
 	</svelte:element>
 </Node>
 

--- a/src/routes/components/Toolbar.svelte
+++ b/src/routes/components/Toolbar.svelte
@@ -109,7 +109,7 @@
 
 	function update_url() {
 		const tr = session.tr;
-		if (session.selection.path.at(-1) === 'label') {
+		if (session.selection.path.at(-1) === 'content') {
 			// We are updating the href property of a button
 			tr.set([...session.selection.path.slice(0, -1), 'href'], input_ref.value);
 		} else {

--- a/src/routes/create_demo_session.js
+++ b/src/routes/create_demo_session.js
@@ -88,9 +88,9 @@ export const document_schema = define_document_schema({
 		}
 	},
 	button: {
-		kind: 'block',
+		kind: 'text',
 		properties: {
-			label: {
+			content: {
 				type: 'annotated_text',
 				node_types: [],
 				allow_newlines: false
@@ -252,7 +252,7 @@ const doc = {
 		button_1: {
 			id: 'button_1',
 			type: 'button',
-			label: { text: 'Get started', annotations: [] },
+			content: { text: 'Get started', annotations: [] },
 			href: 'https://github.com/michael/svedit'
 		},
 		story_1: {
@@ -584,7 +584,7 @@ export const session_config = {
 			return `<${tag_name}>${node.content.text}</${tag_name}>\n`;
 		},
 		button: (node) => {
-			return `<a href="${node.href}">${node.label.text}</a>\n`;
+			return `<a href="${node.href}">${node.content.text}</a>\n`;
 		},
 		image_grid_item: (node) => {
 			let html = '<div class="image-grid-item">\n';
@@ -640,8 +640,8 @@ export const session_config = {
 			const new_button = {
 				id: nanoid(),
 				type: 'button',
-				label: { text: '', annotations: [] },
-				href: 'https://editable.website'
+				content: { text: '', annotations: [] },
+				href: ''
 			};
 			tr.create(new_button);
 			const new_story = {
@@ -740,20 +740,20 @@ export const session_config = {
 				focus_offset: tr.selection.focus_offset
 			});
 		},
-		button: function (tr) {
+		button: function (tr, content = { text: '', annotations: [] }) {
 			const new_button = {
 				id: nanoid(),
 				type: 'button',
-				label: { text: '', annotations: [] },
-				href: 'https://editable.website'
+				content,
+				href: ''
 			};
 			tr.create(new_button);
 			tr.insert_nodes([new_button.id]);
 			tr.set_selection({
-				type: 'node',
-				path: [...tr.selection.path],
-				anchor_offset: tr.selection.focus_offset,
-				focus_offset: tr.selection.focus_offset
+				type: 'text',
+				path: [...tr.selection.path, tr.selection.focus_offset - 1, 'content'],
+				anchor_offset: 0,
+				focus_offset: 0
 			});
 		},
 		hero: function (tr) {

--- a/src/routes/perftest/+page.svelte
+++ b/src/routes/perftest/+page.svelte
@@ -47,7 +47,7 @@
 					const bid = nanoid();
 					nodes[bid] = {
 						id: bid, type: 'button',
-						label: { text: `Action ${b + 1}`, annotations: [] },
+						content: { text: `Action ${b + 1}`, annotations: [] },
 						href: '#'
 					};
 					btn_ids.push(bid);
@@ -315,7 +315,7 @@
 				if (i < count) {
 					const id = nanoid();
 					const tr = session.tr;
-					tr.create({ id, type: 'button', label: { text: `Btn ${i + 1}`, annotations: [] }, href: '#' });
+					tr.create({ id, type: 'button', content: { text: `Btn ${i + 1}`, annotations: [] }, href: '#' });
 					const current = [...session.doc.nodes[target.node_id][target.prop]];
 					current.push(id);
 					tr.set([target.node_id, target.prop], current);

--- a/src/routes/perftest/+page.svelte
+++ b/src/routes/perftest/+page.svelte
@@ -346,18 +346,16 @@
 		const debounce_values = [0, 5, 10, 20];
 		const node_counts = [200, 500, 1000, 6000];
 		const results = [];
-		
+
 		is_testing = true;
-		
+
 		for (const overscan of overscan_values) {
 			for (const debounce of debounce_values) {
 				/** @type {any} */ (window).__culling_config.overscan = overscan;
 				/** @type {any} */ (window).__culling_config.debounce = debounce;
-				
+
 				for (const count of node_counts) {
 					node_count = count;
-					
-					const t0 = performance.now();
 					session = make_session();
 					mount_key++;
 					await tick();
@@ -365,26 +363,26 @@
 					await new Promise(r => requestAnimationFrame(r));
 					await new Promise(r => setTimeout(r, 1000));
 					if (count >= 2000) await new Promise(r => setTimeout(r, 3000));
-					
+
 					const scroll = await quick_scroll_test(2000);
 					await new Promise(r => setTimeout(r, 200));
-					
+
 					const dom = document.querySelectorAll('.svedit *').length;
 					const gap_mk = document.querySelectorAll('.gap-marker').length;
 					const perf = /** @type {any} */ (performance);
 					const mem = perf.memory ? Math.round(perf.memory.usedJSHeapSize / 1024 / 1024) : null;
-					
+
 					results.push({
 						overscan, debounce, nodes: count,
 						scroll_avg: scroll.avg, scroll_min: scroll.min,
 						dom, gaps: gap_mk, mem
 					});
-					
+
 					console.log(`overscan=${overscan} debounce=${debounce} nodes=${count}: scroll=${scroll.avg}/${scroll.min} dom=${dom} gaps=${gap_mk}`);
 				}
 			}
 		}
-		
+
 		/** @type {any} */ (window).__matrix_results = results;
 		console.log('DONE', JSON.stringify(results));
 		is_testing = false;

--- a/src/test/Svedit.svelte.test.js
+++ b/src/test/Svedit.svelte.test.js
@@ -81,7 +81,7 @@ describe('Svedit.svelte', () => {
 
 		expect(original_story.title).toEqual({ text: 'First story', annotations: [] });
 		expect(original_story.buttons).toEqual(['button_1']);
-		expect(original_button.label).toEqual({ text: 'Get started', annotations: [] });
+		expect(original_button.content).toEqual({ text: 'Get started', annotations: [] });
 
 		// Initial body state: ['story_1, 'story_1, 'list_1]
 		const initial_body = session.get(['page_1', 'body']);
@@ -177,7 +177,7 @@ describe('Svedit.svelte', () => {
 			text: 'First story description.',
 			annotations: []
 		});
-		expect(first_new_button.label).toEqual({ text: 'Get started', annotations: [] });
+		expect(first_new_button.content).toEqual({ text: 'Get started', annotations: [] });
 		expect(first_new_button.href).toBe('https://github.com/michael/svedit');
 
 		// But IDs should be different
@@ -225,7 +225,7 @@ describe('Svedit.svelte', () => {
 			text: 'First story description.',
 			annotations: []
 		});
-		expect(second_new_button.label).toEqual({ text: 'Get started', annotations: [] });
+		expect(second_new_button.content).toEqual({ text: 'Get started', annotations: [] });
 		expect(second_new_button.href).toBe('https://github.com/michael/svedit');
 
 		// But IDs should be different from both original and first paste

--- a/src/test/create_test_session.js
+++ b/src/test/create_test_session.js
@@ -31,9 +31,9 @@ const document_schema = define_document_schema({
 		}
 	},
 	button: {
-		kind: 'block',
+		kind: 'text',
 		properties: {
-			label: { type: 'annotated_text', allow_newlines: false },
+			content: { type: 'annotated_text', allow_newlines: false },
 			href: { type: 'string' }
 		}
 	},
@@ -79,7 +79,7 @@ const doc = {
 		button_1: {
 			id: 'button_1',
 			type: 'button',
-			label: { text: 'Get started', annotations: [] },
+			content: { text: 'Get started', annotations: [] },
 			href: 'https://github.com/michael/svedit'
 		},
 		story_1: {
@@ -137,20 +137,20 @@ const session_config = {
 		list_item: 1
 	},
 	inserters: {
-		button: function (tr) {
+		button: function (tr, content = { text: '', annotations: [] }) {
 			const new_button = {
 				id: nanoid(),
 				type: 'button',
-				label: { text: '', annotations: [] },
+				content,
 				href: 'https://editable.website'
 			};
 			tr.create(new_button);
 			tr.insert_nodes([new_button.id]);
 			tr.set_selection({
-				type: 'node',
-				path: [...tr.selection.path],
-				anchor_offset: tr.selection.focus_offset,
-				focus_offset: tr.selection.focus_offset
+				type: 'text',
+				path: [...tr.selection.path, tr.selection.focus_offset - 1, 'content'],
+				anchor_offset: 0,
+				focus_offset: 0
 			});
 		},
 		text: function (tr, content) {
@@ -174,7 +174,7 @@ const session_config = {
 			const new_button = {
 				id: nanoid(),
 				type: 'button',
-				label: { text: '', annotations: [] },
+				content: { text: '', annotations: [] },
 				href: 'https://editable.website'
 			};
 			tr.create(new_button);

--- a/src/test/test_utils.js
+++ b/src/test/test_utils.js
@@ -43,6 +43,7 @@ export const settle_grid = () => settle({ rafs: 8, ms: 150 });
 /** Build a session with a single story whose `buttons` array holds `n` buttons. */
 export function make_story_session(n_buttons) {
 	const button_ids = [];
+	/** @type {import('../lib/types.d.ts').Document['nodes']} */
 	const nodes = {};
 	for (let i = 0; i < n_buttons; i++) {
 		const id = `btn_${i}`;
@@ -77,6 +78,7 @@ export function make_story_session(n_buttons) {
 /** Build a session with a single image_grid containing `n` items. */
 export function make_image_grid_session(n_items) {
 	const item_ids = [];
+	/** @type {import('../lib/types.d.ts').Document['nodes']} */
 	const nodes = {};
 	for (let i = 0; i < n_items; i++) {
 		const id = `igi_${i}`;

--- a/src/test/test_utils.js
+++ b/src/test/test_utils.js
@@ -49,7 +49,7 @@ export function make_story_session(n_buttons) {
 		nodes[id] = {
 			id,
 			type: 'button',
-			label: { text: `Action ${i + 1}`, annotations: [] },
+			content: { text: `Action ${i + 1}`, annotations: [] },
 			href: '#'
 		};
 		button_ids.push(id);


### PR DESCRIPTION
This makes story.buttons behave like text with respect to split/join on ENTER/BACKSPACE.

New nodes created on split just get the default values of the inserter for now. Sometimes you might want to inherit properties from the node you split, but need to collect more use-cases for that. Might require some additional config so you can hook into that behavior if needed. But I think creating a fresh node with defaults is a good default behavior.

Kept the rule that text nodes need to have a 'content' property, then Svedit can do static analysis. That's more robust, then some implicit "use the first annotated_text property" at runtime.

Also added some type checking, you get errors if you try to make a node kind: 'text' without a content property or with additional annotated_text properties.