### PR TITLE
Allow switching annotation types when safe

### DIFF
--- a/src/lib/Command.svelte.js
+++ b/src/lib/Command.svelte.js
@@ -1,4 +1,5 @@
 import { insert_default_node, break_text_node } from './transforms.svelte.js';
+import { can_switch_annotation_type } from './doc_utils.js';
 import { is_selection_collapsed, is_mobile_browser, get_char_length } from './utils.js';
 
 /**
@@ -123,14 +124,24 @@ export class ToggleAnnotationCommand extends Command {
 
 	is_enabled() {
 		const { session, editable } = this.context;
+		const active_annotation = session.active_annotation();
 		const has_annotation = session.active_annotation(this.node_type);
+		const can_switch_annotation =
+			active_annotation &&
+			!has_annotation &&
+			session.available_annotation_types.includes(this.node_type) &&
+			can_switch_annotation_type(
+				session.schema,
+				session.get(active_annotation.node_id),
+				this.node_type
+			);
 		const no_annotation_and_caret_not_collapsed =
-			!session.active_annotation() && !is_selection_collapsed(session.selection);
+			!active_annotation && !is_selection_collapsed(session.selection);
 
 		return (
 			editable &&
 			session.selection?.type === 'text' &&
-			(has_annotation || no_annotation_and_caret_not_collapsed)
+			(has_annotation || can_switch_annotation || no_annotation_and_caret_not_collapsed)
 		);
 	}
 

--- a/src/lib/Transaction.svelte.js
+++ b/src/lib/Transaction.svelte.js
@@ -19,7 +19,8 @@ import {
 	count_references_excluding_deleted,
 	validate_node,
 	get_active_annotation,
-	validate_selection
+	validate_selection,
+	can_switch_annotation_type
 } from './doc_utils.js';
 
 /**
@@ -438,6 +439,8 @@ export default class Transaction {
 		const annotations = annotated_text.annotations;
 		const existing_annotation = this.active_annotation();
 		const existing_annotation_same_type = this.active_annotation(annotation_type);
+		const has_annotation_properties =
+			annotation_properties && Object.keys(annotation_properties).length > 0;
 
 		if (existing_annotation) {
 			// If there's an existing annotation of the same type, remove it
@@ -453,7 +456,22 @@ export default class Transaction {
 					annotations.splice(index, 1);
 				}
 			} else {
-				// If there's an annotation of a different type, don't add a new one
+				const existing_annotation_node = this.get(existing_annotation.node_id);
+				const can_switch_annotation =
+					!has_annotation_properties &&
+					this.available_annotation_types.includes(annotation_type) &&
+					can_switch_annotation_type(
+						this.schema,
+						existing_annotation_node,
+						annotation_type
+					);
+
+				if (can_switch_annotation) {
+					this.set([existing_annotation.node_id, 'type'], annotation_type);
+					return this;
+				}
+
+				// If there's an annotation of a different incompatible type, don't add a new one
 				return this;
 			}
 		} else {

--- a/src/lib/doc_utils.js
+++ b/src/lib/doc_utils.js
@@ -438,6 +438,31 @@ export function kind(schema, node) {
 }
 
 /**
+ * Checks whether an annotation node can be switched to another annotation type
+ * without losing data.
+ *
+ * @param {DocumentSchema} schema - The document schema
+ * @param {any} annotation_node - The annotation node to switch
+ * @param {string} target_annotation_type - The target annotation type
+ * @returns {boolean} True if the annotation can be switched safely
+ */
+export function can_switch_annotation_type(schema, annotation_node, target_annotation_type) {
+	if (!annotation_node || annotation_node.type === target_annotation_type) return false;
+
+	const source_schema = schema[annotation_node.type];
+	const target_schema = schema[target_annotation_type];
+	if (source_schema?.kind !== 'annotation' || target_schema?.kind !== 'annotation') return false;
+
+	const source_has_properties = Object.keys(source_schema.properties ?? {}).length > 0;
+	const target_has_properties = Object.keys(target_schema.properties ?? {}).length > 0;
+	if (source_has_properties || target_has_properties) return false;
+
+	// eslint-disable-next-line no-unused-vars
+	const { id, type, ...extra_properties } = annotation_node;
+	return Object.keys(extra_properties).length === 0;
+}
+
+/**
  * Inspects a path to get metadata about the value at that location.
  *
  * @param {DocumentSchema} schema - The document schema


### PR DESCRIPTION
E.g. you can turn a strong annotation into an emphasis, without having to first delete it then re-create it.