### PR TITLE
Fix empty node array gap not filling its placeholder

### DIFF
--- a/src/lib/NodeArrayProperty.svelte
+++ b/src/lib/NodeArrayProperty.svelte
@@ -96,11 +96,14 @@
 </svelte:element>
 
 <style>
-/* If you override this to position: absolute (e.g. so an empty array
-   doesn't occupy flow space), set position: relative on the parent
-   node-array container so left/right or inset resolve against it. */
+/* position: relative makes this the containing block for the gap's
+   .svedit-selectable, which fills it via inset:0. You may override to
+   position: absolute (e.g. so an empty array doesn't occupy flow space)
+   — still a containing block; then also set position: relative on the
+   parent node-array container so this placeholder's inset:0 resolves
+   against it. */
 	:where(.empty-node-placeholder) {
-		position: static;
+		position: relative;
 		inset: 0;
 		min-height: 40px;
 		min-width: 24px;

--- a/src/lib/NodeGap.svelte
+++ b/src/lib/NodeGap.svelte
@@ -358,12 +358,21 @@
 		min-width: calc(var(--_eg) * var(--_R));
 	}
 
-	/* Empty array: spans the outermost edges of placeholder and container. */
-	:global(.node-gap.positioned.gap-before.empty .svedit-selectable) {
-		top: min(var(--_s-t), var(--_c-t));
-		bottom: min(var(--_s-b), var(--_c-b));
-		left: min(var(--_s-l), var(--_c-l));
-		right: min(var(--_s-r), var(--_c-r));
+	/* Empty array: the gap fills its placeholder, which is this
+	   selectable's containing block (NodeArrayProperty sets it
+	   position: relative). inset:0 fills it with no anchor() — so no
+	   .positioned gating and no anchor cost. The width:auto, height:auto
+	   and pointer-events:auto override the :not(.positioned) 0×0
+	   collapse; position-visibility:always overrides the .positioned
+	   rule's anchors-visible, so a transient positioned toggle can't
+	   hide the gap. */
+	:global(.node-gap.gap-before.empty .svedit-selectable) {
+		position: absolute;
+		inset: 0;
+		width: auto;
+		height: auto;
+		pointer-events: auto;
+		position-visibility: always;
 	}
 
 	/* Debugging styles - DO NOT CHANGE OR REMOVE */


### PR DESCRIPTION
An empty node array's gap (`.svedit-selectable`) had no usable hit area.

## Root cause

The empty gap's selectable was sized by `min(anchor(--placeholder), anchor(--container))` and gated on the `.positioned` class. Two compounding failures:

1. **It never got `.positioned` on initial render.** `.positioned` is toggled by `sync_gap_class()`, reached via `#process_near` → `sync_gaps_around_node()` — which only inspects a node's *siblings* for a `.node-gap`. An empty array's gap is nested *inside* the `.empty-node-placeholder` as a *child*, so it was never synced; its selectable stayed collapsed at `0 × 0`.

2. **Even positioned, the anchor math collapsed it.** Where the placeholder is absolutely positioned (e.g. the Story `buttons` array), `anchor(--container …)` resolved only the start-side edges — `right`/`bottom` fell through to `auto`, and the selectable shrink-wrapped to its `<br>`: a zero-width hit area.

## Fix

An empty array's gap doesn't need anchor positioning. Anchor positioning places a gap in the whitespace *between sibling nodes*; an empty array has none. Its gap just has to fill one box — the placeholder.

- **`NodeArrayProperty.svelte`** — `.empty-node-placeholder` is now `position: relative`, making it the containing block for its gap's selectable.
- **`NodeGap.svelte`** — the empty-gap selectable fills the placeholder with `inset: 0`. No `anchor()`, so no `.positioned` gating and no anchor-resolution cost; the rule applies unconditionally.

The hit area is now exactly the placeholder — which the app already sizes (in flow, out of flow, or zero) — and `node_visibility` no longer touches the empty gap at all.

## Test plan

- [x] Empty node array on screen: its `.svedit-selectable` fills the placeholder (real size, `pointer-events: auto`).
- [x] A pointer gesture inside an empty array reaches the gap.
- [x] Works with an absolutely-positioned placeholder (Story `buttons`).
- [x] Non-empty arrays: gap positioning unchanged.
