### PR TITLE
Fix node-selection scroll-into-view crash and wrong target

### DIFF
--- a/src/lib/Svedit.svelte
+++ b/src/lib/Svedit.svelte
@@ -1230,8 +1230,12 @@ ${fallback_html}`;
 
 			// If either node flanking the cursor is already (even
 			// partially) on screen, the cursor is visible — keep the
-			// viewport stable and scroll nothing.
-			const node_before = __get_node_element(node_array_path, cursor_offset - 1);
+			// viewport stable and scroll nothing. node_before is null at
+			// offset 0: cursor_offset - 1 would be -1, and serialize_path
+			// rejects a negative index.
+			const node_before = cursor_offset > 0
+				? __get_node_element(node_array_path, cursor_offset - 1)
+				: null;
 			const node_after = __get_node_element(node_array_path, cursor_offset);
 			if (__intersects_viewport(node_before) || __intersects_viewport(node_after)) return;
 
@@ -1256,7 +1260,12 @@ ${fallback_html}`;
 				}
 				return;
 			}
-			node_after?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+			// A range selection's selected node IS node_before; scrolling
+			// node_after would reveal the following node and leave the
+			// selection itself off-screen. For a collapsed caret node_after's
+			// leading edge is the cursor, so that stays the right target.
+			const target = is_collapsed ? node_after : node_before;
+			target?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
 		}, 0);
 	}
 


### PR DESCRIPTION
Fix for the issues #289  and #288 

---

### 289 — crash when a node caret sits at offset 0 (critical)

A regression from #287. It added an unconditional lookup:

```js
const node_before = __get_node_element(node_array_path, cursor_offset - 1);
```

When the caret is at the first gap (`cursor_offset === 0`), `cursor_offset - 1` is `-1`, and `serialize_path` throws `Path index must be a non-negative integer: -1`.

Fixed by skipping the lookup at offset 0:

```js
const node_before = cursor_offset > 0
    ? __get_node_element(node_array_path, cursor_offset - 1)
    : null;
```

### 288 — off-screen node selection scrolled to the wrong node

The general case scrolled `node_after` — the node *after* the selection (`node[cursor_offset]`). For a node-range selection the selected node is `node_before` (`node[cursor_offset - 1]`), so the scroll revealed the following node and left the selection itself off-screen above. The miss equals the selected node's height — which is why a taller story is "off more".

Fixed by scrolling the selected node for range selections; a collapsed caret keeps `node_after`, whose leading edge is the cursor:

```js
const target = is_collapsed ? node_after : node_before;
target?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
```
