### PR TITLE
Expose anchor-name and gap path/offset on .gap-marker

### DIFF
--- a/src/lib/NodeGapMarkers.svelte
+++ b/src/lib/NodeGapMarkers.svelte
@@ -147,7 +147,9 @@
 		class:first={gap.is_first}
 		class:last={gap.is_last}
 		class:pair={gap.has_pair}
-		style={gap.vars}
+		style={`${gap.vars};anchor-name:--gm-${gap.key}`}
+		data-gap-array-path={path_str}
+		data-gap-offset={gap.offset}
 		contenteditable="false"
 	>
 		{#if gap.key === caret_gap_key}


### PR DESCRIPTION
## Summary

Three attributes per marker so consumers can target a specific gap from CSS / JS without re-deriving its geometry:
- `anchor-name: --gm-<key>` — CSS anchor positioning for popovers/menus pinned to a gap
- `data-gap-array-path` + `data-gap-offset` — path-based lookup

No behavior change inside svedit; existing styling and caret logic ignore them.

## Test plan

- [x] svedit-lab smoke tests still pass
- [x] Existing gap-marker appearance and caret behavior unchanged in editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)