### PR TITLE
register_mount: refcount + microtask-deferred duplicate check

### DIFF
--- a/src/lib/Session.svelte.js
+++ b/src/lib/Session.svelte.js
@@ -66,35 +66,62 @@ export default class Session {
 	available_annotation_types = $derived(this.get_available_annotation_types());
 
 	/**
-	 * Tracks paths currently mounted in the DOM. Within one Svedit document, each
-	 * path may be mounted exactly once. Used by NodeArrayProperty to detect
-	 * duplicate mounts in dev mode.
-	 * @type {Record<string, true>}
+	 * Tracks paths currently mounted in the DOM, by reference count. Within
+	 * one Svedit document a given path may be mounted exactly once at steady
+	 * state — but a transient overlap of 2 (one mounting, one unmounting on
+	 * the same microtask) is legal during a consumer-driven swap, e.g. a
+	 * `{#key …}<Svedit … />{/key}` flip where Svelte builds the new subtree
+	 * before the old one's $effect cleanups run. We refcount the mounts and
+	 * defer the duplicate check to a microtask so genuine overlaps that
+	 * resolve themselves don't fire a false-positive console error.
+	 * @type {Map<string, number>}
 	 */
-	#mounted_paths = $state.raw({});
+	#mounted_paths = new Map();
+
+	/** Set of paths with a pending overlap check queued. Keeps us from
+	 *  enqueueing one microtask per registration when the same path
+	 *  bounces register → unregister → register inside a single sync block.
+	 * @type {Set<string>}
+	 */
+	#pending_overlap_checks = new Set();
 
 	/**
-	 * Registers a path as mounted. Logs an error if the path is
-	 * already mounted (a duplicate mount breaks anchor positioning, IO tracking,
-	 * id uniqueness, gap signals and selection mapping).
+	 * Registers a path as mounted. A second concurrent mount of the same
+	 * path schedules a microtask check — if the count is still > 1 once
+	 * Svelte has drained pending effect cleanups, that's a real duplicate
+	 * (two mounts living side-by-side, which breaks anchor positioning,
+	 * IO tracking, id uniqueness, gap signals and selection mapping) and
+	 * we log. A swap window unwinds the count before the check fires.
 	 * @param {string} path_str
 	 */
 	register_mount(path_str) {
-		if (this.#mounted_paths[path_str]) {
-			console.error(
-				`[svedit] Path "${path_str}" is mounted more than once. Within a single Svedit document, each path may be mounted exactly once. To render shared content in multiple places (e.g. header + footer nav), use distinct node_arrays or separate Svedit instances.`
-			);
-			return;
+		const next = (this.#mounted_paths.get(path_str) || 0) + 1;
+		this.#mounted_paths.set(path_str, next);
+		if (next > 1 && !this.#pending_overlap_checks.has(path_str)) {
+			this.#pending_overlap_checks.add(path_str);
+			queueMicrotask(() => {
+				this.#pending_overlap_checks.delete(path_str);
+				const count = this.#mounted_paths.get(path_str) || 0;
+				if (count > 1) {
+					console.error(
+						`[svedit] Path "${path_str}" is mounted more than once. Within a single Svedit document, each path may be mounted exactly once. To render shared content in multiple places (e.g. header + footer nav), use distinct node_arrays or separate Svedit instances.`
+					);
+				}
+			});
 		}
-		this.#mounted_paths[path_str] = true;
 	}
 
 	/**
-	 * Unregisters a previously registered path on unmount.
+	 * Unregisters a previously registered path on unmount. Decrements the
+	 * refcount; deletes the entry when it drops to zero so the map stays
+	 * bounded by the live mount set, not the lifetime mount set.
 	 * @param {string} path_str
 	 */
 	unregister_mount(path_str) {
-		delete this.#mounted_paths[path_str];
+		const count = this.#mounted_paths.get(path_str);
+		if (!count) return;
+		if (count <= 1) this.#mounted_paths.delete(path_str);
+		else this.#mounted_paths.set(path_str, count - 1);
 	}
 
 	/**


### PR DESCRIPTION
## Root problems

**1. `register_mount` is intolerant of Svelte's mount/unmount ordering.**

`{#key …}` (and other conditional renders) mount the new subtree *before* the old subtree's `$effect` cleanups run. For one microtask, both subtrees coexist and both register the same paths. The current synchronous check fires `console.error` on this transient overlap — a false positive on a legal Svelte pattern.

**2. The check is unreliable even when it does catch a real duplicate.**

When it sees a second register, it bails *without recording it*. The first `unregister_mount` then deletes the registry entry — leaving the second mount unrecorded. Any future duplicate of that same path will not fire the check, because the registry no longer knows the path is mounted at all.

## How it surfaces (real-world example)

A consumer with a large reactive doc (~144 components reading `svedit.editable`) finds that reactively toggling `editable={…}` walks every component — slow (~705ms `tick()`). They wrap `<Svedit/>` in `{#key is_edit_mode}` to take the mount path instead (~325ms). Every toggle then spams 50+ `[svedit] Path "…" is mounted more than once.` errors. Final DOM state is correct — just noise.

## Fix

- `#mounted_paths`: `Record<string, true>` → `Map<string, number>` (refcounted)
- `register_mount` queues a one-shot microtask check when count goes > 1; logs only if count is still > 1 after Svelte drains pending cleanups
- A transient swap-window overlap unwinds before the check fires → silent
- A persistent overlap (header + footer rendering the same path) still warns
- The refcount also fixes problem #2 incidentally: the second register is recorded, the first unregister only decrements

## Test plan

- [ ] Mount a path twice synchronously, do not unregister → `console.error` fires after the microtask
- [ ] Mount, mount, unmount in one sync block → no error
- [ ] Real-world: cmd+E toggle on a `{#key …}<Svedit/>` consumer goes from 50+ errors per swap to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)