### PR TITLE
Remove per-component mount registry

### DIFF
--- a/src/lib/AnnotatedTextProperty.svelte
+++ b/src/lib/AnnotatedTextProperty.svelte
@@ -110,13 +110,6 @@
 		return fragments;
 	}
 
-	// Enforce the "one path = one DOM mount per document" invariant
-	$effect(() => {
-		const current_session = svedit.session;
-		const current_path_str = path_str;
-		current_session.register_mount(current_path_str);
-		return () => current_session.unregister_mount(current_path_str);
-	});
 </script>
 
 <!-- ATTENTION: The comments are needed to prevent unwanted text nodes with whitespace. -->

--- a/src/lib/CustomProperty.svelte
+++ b/src/lib/CustomProperty.svelte
@@ -9,13 +9,6 @@
 	let { path, tag = 'div', class: css_class, children, style, ...rest } = $props();
 	let path_str = $derived(serialize_path(path));
 
-	// Enforce the "one path = one DOM mount per document" invariant
-	$effect(() => {
-		const current_session = svedit.session;
-		const current_path_str = path_str;
-		current_session.register_mount(current_path_str);
-		return () => current_session.unregister_mount(current_path_str);
-	});
 </script>
 
 <svelte:element

--- a/src/lib/NodeArrayProperty.svelte
+++ b/src/lib/NodeArrayProperty.svelte
@@ -36,13 +36,6 @@
 		}
 	});
 
-	// Enforce the "one path = one DOM mount per document" invariant
-	$effect(() => {
-		const current_session = svedit.session;
-		const current_path_str = path_str;
-		current_session.register_mount(current_path_str);
-		return () => current_session.unregister_mount(current_path_str);
-	});
 </script>
 
 <!-- we use the anchor of node_array in Overlays.svelte to position the last insertion point in a horizontal layout based on the right edge of the container -->

--- a/src/lib/Session.svelte.js
+++ b/src/lib/Session.svelte.js
@@ -65,37 +65,6 @@ export default class Session {
 	selected_node = $derived(this.get_selected_node());
 	available_annotation_types = $derived(this.get_available_annotation_types());
 
-	/**
-	 * Tracks paths currently mounted in the DOM. Within one Svedit document, each
-	 * path may be mounted exactly once. Used by NodeArrayProperty to detect
-	 * duplicate mounts in dev mode.
-	 * @type {Record<string, true>}
-	 */
-	#mounted_paths = $state.raw({});
-
-	/**
-	 * Registers a path as mounted. Logs an error if the path is
-	 * already mounted (a duplicate mount breaks anchor positioning, IO tracking,
-	 * id uniqueness, gap signals and selection mapping).
-	 * @param {string} path_str
-	 */
-	register_mount(path_str) {
-		if (this.#mounted_paths[path_str]) {
-			console.error(
-				`[svedit] Path "${path_str}" is mounted more than once. Within a single Svedit document, each path may be mounted exactly once. To render shared content in multiple places (e.g. header + footer nav), use distinct node_arrays or separate Svedit instances.`
-			);
-			return;
-		}
-		this.#mounted_paths[path_str] = true;
-	}
-
-	/**
-	 * Unregisters a previously registered path on unmount.
-	 * @param {string} path_str
-	 */
-	unregister_mount(path_str) {
-		delete this.#mounted_paths[path_str];
-	}
 
 	/**
 	 * @param {DocumentSchema} schema - The document schema

--- a/src/lib/Svedit.svelte
+++ b/src/lib/Svedit.svelte
@@ -81,6 +81,32 @@
 	setContext('svedit', context);
 	create_node_visibility(context);
 
+	$effect(() => {
+		check_duplicate_paths();
+	});
+
+	function check_duplicate_paths() {
+		if (!canvas_el) return;
+
+		/** @type {Record<string, true>} */
+		const mounted_paths = Object.create(null);
+
+		for (const element of canvas_el.querySelectorAll('[data-path]')) {
+			if (element.closest('.svedit-canvas') !== canvas_el) continue;
+
+			const path_str = element.getAttribute('data-path');
+			if (!path_str) continue;
+
+			if (mounted_paths[path_str]) {
+				console.warn(
+					`[svedit] Path "${path_str}" is mounted more than once. Within a single Svedit document, each path may be mounted exactly once. To render shared content in multiple places (e.g. header + footer nav), use distinct node_arrays or separate Svedit instances.`
+				);
+			}
+
+			mounted_paths[path_str] = true;
+		}
+	}
+
 	// Test-only hook: expose the svedit context so test specs can read
 	// near_map / edge_map for diagnostics. Gated on `import.meta.env.MODE`
 	// — Vite replaces the literal so the comparison is constant-false in


### PR DESCRIPTION
Delete per-component register_mount and Session mounted_paths state.

Add an $effect scanning the DOM in Svedit that warns when multiple elements in the canvas share the same data-path.