### PR TITLE
Simplify: collapse near_map into array_indices as the single near-state store

### DIFF
--- a/src/lib/NodeGap.svelte
+++ b/src/lib/NodeGap.svelte
@@ -39,8 +39,9 @@
 	 * Always present in the DOM when editable (stable structure for
 	 * selection anchoring, scrollTo, etc.). Anchor positioning is
 	 * activated lazily via the `.positioned` class, derived reactively
-	 * from the visibility registry's near_map / edge_map. SvelteMap
-	 * tracks reads at per-key granularity, so a registry write only
+	 * from the visibility registry's array_indices / edge_map. Svelte's
+	 * reactive collections track reads at per-key granularity, so a
+	 * registry write only
 	 * re-evaluates the adjacent gaps. Applying the class declaratively
 	 * (instead of imperative classList toggles) means it survives DOM
 	 * recreation without a document change (e.g. dev-mode HMR).
@@ -66,9 +67,19 @@
 	let type = $derived(is_first ? 'gap-before' : 'gap-after');
 
 	let path_str = $derived(serialize_path(array_path));
+	// Two-derived split is load-bearing: get_array_indices lazily
+	// creates the set, and Svelte doesn't track deps on state created
+	// inside the reading derived — so acquire here, read in `positioned`.
+	let near_indices = $derived(svedit.visibility_registry.get_array_indices(path_str));
 	let positioned = $derived(
 		is_editable &&
-			should_position_gap(svedit.visibility_registry, path_str, offset, is_last, empty)
+			should_position_gap(
+				near_indices,
+				svedit.visibility_registry.edge_map.get(path_str),
+				offset,
+				is_last,
+				empty
+			)
 	);
 
 	let gap_style = $derived.by(() => {

--- a/src/lib/Svedit.svelte
+++ b/src/lib/Svedit.svelte
@@ -118,7 +118,7 @@
 	}
 
 	// Test-only hook: expose the svedit context so test specs can read
-	// near_map / edge_map for diagnostics. Gated on `import.meta.env.MODE`
+	// array_indices / edge_map for diagnostics. Gated on `import.meta.env.MODE`
 	// — Vite replaces the literal so the comparison is constant-false in
 	// production and the branch is dead-code-eliminated. Wrapped in an
 	// effect so unmount clears the reference and tests don't leak state

--- a/src/lib/node_visibility.svelte.js
+++ b/src/lib/node_visibility.svelte.js
@@ -34,9 +34,9 @@
  *
  * ## Two observers
  *
- * **Overscan IO** (`rootMargin: 500px`, threshold `0`) — fills
- * `near_map` and per-array `array_indices`. NodeGap derives its
- * `.positioned` class reactively from these maps. Registration seeds
+ * **Overscan IO** (`rootMargin: 500px`, threshold `0`) — fills the
+ * per-array `array_indices` sets. NodeGap derives its `.positioned`
+ * class reactively from them. Registration seeds
  * the state synchronously from one getBoundingClientRect (so there's
  * no unpositioned flash on mount); the IO owns subsequent viewport
  * transitions, including layout-shift-induced ones.
@@ -70,8 +70,9 @@
  *
  * ## Reactivity
  *
- * State lives in SvelteMap (near_map, edge_map) and per-array SvelteSet
- * (array_indices). Consumers (NodeGap and NodeGapMarkers, both via
+ * State lives in per-array SvelteSets (array_indices, the single
+ * source of truth for node nearness) and a SvelteMap (edge_map).
+ * Consumers (NodeGap and NodeGapMarkers, both via
  * $derived) read via .has()/.get() — Svelte's runtime tracks at
  * per-key granularity, so only consumers whose specific dependencies
  * changed re-evaluate. Because the `.positioned` class is applied
@@ -112,13 +113,12 @@ const EDGE_TOLERANCE_PX = 10;
  * the track_node / track_array attachments.
  */
 class VisibilityRegistry {
-	/** Per-node "in overscan zone" flag. NodeGap reads via `.has(path)`. */
-	near_map = new SvelteMap();
-
 	/**
-	 * Per-array set of near child indices. NodeGapMarkers iterates the
-	 * set for its array. Stable references — once a SvelteSet is created
-	 * for an array path it survives re-renders so consumers stay subscribed.
+	 * Per-array set of near ("in overscan zone") child indices — the
+	 * single source of truth for node nearness. NodeGap reads via
+	 * `.has(index)`, NodeGapMarkers iterates the set for its array.
+	 * Stable references — once a SvelteSet is created for an array path
+	 * it survives re-renders so consumers stay subscribed.
 	 *
 	 * @type {Map<string, SvelteSet<number>>}
 	 */
@@ -203,7 +203,7 @@ class VisibilityRegistry {
 	view_classes = true;
 
 	/**
-	 * When true, the overscan IO populates near_map and NodeGap gates
+	 * When true, the overscan IO populates array_indices and NodeGap gates
 	 * `.positioned` by viewport proximity. When false, the overscan IO
 	 * is skipped and every registered node counts as near, so every gap
 	 * is `.positioned` and every marker renders.
@@ -254,7 +254,6 @@ class VisibilityRegistry {
 		this.#near_nodes.clear();
 		this.#array_els.clear();
 		this.#array_owners.clear();
-		this.near_map.clear();
 		this.edge_map.clear();
 		for (const set of this.#array_indices.values()) set.clear();
 	}
@@ -264,6 +263,13 @@ class VisibilityRegistry {
 	 * Callers should hold the returned reference for the lifetime of the
 	 * subscription — the same set is returned on subsequent calls so
 	 * Svelte's per-set tracking remains intact across re-evaluations.
+	 *
+	 * IMPORTANT: hold the returned set in its own $derived and read
+	 * membership from a different one (see NodeGap / NodeGapMarkers).
+	 * Svelte does not track dependencies on state created inside the
+	 * currently-evaluating reaction, so a consumer that lazily creates
+	 * the set and reads `.has()` in the same derived never subscribes
+	 * and never re-evaluates.
 	 *
 	 * @param {string} array_path_str
 	 * @returns {SvelteSet<number>}
@@ -394,7 +400,6 @@ class VisibilityRegistry {
 			// have already claimed this path — its state must survive.
 			if (this.#path_owners.get(path) === el) {
 				this.#path_owners.delete(path);
-				this.near_map.delete(path);
 				const split = this.#split_path(path);
 				if (split) this.#array_indices.get(split.array_path)?.delete(split.index);
 			}
@@ -407,7 +412,6 @@ class VisibilityRegistry {
 	 */
 	#add_near_node(el, path) {
 		this.#near_nodes.add(el);
-		this.near_map.set(path, true);
 		const split = this.#split_path(path);
 		if (split) this.get_array_indices(split.array_path).add(split.index);
 	}
@@ -419,7 +423,6 @@ class VisibilityRegistry {
 	#remove_near_node(el, path) {
 		this.#near_nodes.delete(el);
 		if (this.#path_owners.get(path) !== el) return;
-		this.near_map.delete(path);
 		const split = this.#split_path(path);
 		if (split) this.#array_indices.get(split.array_path)?.delete(split.index);
 	}
@@ -512,7 +515,7 @@ class VisibilityRegistry {
 	}
 
 	/**
-	 * Overscan IO callback. Manages near_map and array_indices; NodeGap
+	 * Overscan IO callback. Manages the array_indices sets; NodeGap
 	 * reacts to the map writes and updates .positioned declaratively.
 	 *
 	 * @param {IntersectionObserverEntry[]} entries
@@ -628,27 +631,31 @@ export function create_node_visibility(svedit) {
 }
 
 /**
- * Reactive visibility check for a gap's `.positioned` class. NodeGap
- * calls this from a $derived, so the near_map / edge_map reads are
- * tracked at per-key granularity — a gap re-evaluates only when its
- * own dependencies change. Applying the class declaratively means it
+ * Pure visibility check for a gap's `.positioned` class. NodeGap calls
+ * this from a $derived, so the `near.has()` reads are tracked at
+ * per-key granularity — a gap re-evaluates only when its own
+ * dependencies change. Applying the class declaratively means it
  * survives DOM recreation without a document change (e.g. dev-mode
  * HMR component swaps).
  *
- * @param {VisibilityRegistry} registry
- * @param {string} array_path_str
+ * `near` must come from `get_array_indices` held in a SEPARATE
+ * $derived (see the note there): membership reads on a set created
+ * within the same derived are not tracked by Svelte.
+ *
+ * @param {SvelteSet<number>} near - near child indices of the array
+ * @param {{ first: boolean, last: boolean } | undefined} edge_state
  * @param {number} offset
  * @param {boolean} is_last
  * @param {boolean} empty
  */
-export function should_position_gap(registry, array_path_str, offset, is_last, empty) {
-	if (!registry) return false;
+export function should_position_gap(near, edge_state, offset, is_last, empty) {
+	if (!near) return false;
 
 	if (empty) {
-		return registry.near_map.has(`${array_path_str}${PATH_SEPARATOR}0`);
+		return near.has(0);
 	}
 
-	// Edge gaps gate on near_map AND edge_map. edge_map is the
+	// Edge gaps gate on nearness AND edge state. edge_state is the
 	// scroll-aware check that the adjacent edge node has actually
 	// reached the matching end of its array container (within
 	// EDGE_TOLERANCE_PX). We can't rely on the IO here because it only
@@ -656,17 +663,14 @@ export function should_position_gap(registry, array_path_str, offset, is_last, e
 	// changes within a horizontal-overflow container that don't change
 	// the visibility ratio.
 	if (offset === 0) {
-		if (!registry.near_map.has(`${array_path_str}${PATH_SEPARATOR}0`)) return false;
-		return registry.edge_map.get(array_path_str)?.first === true;
+		if (!near.has(0)) return false;
+		return edge_state?.first === true;
 	}
 
 	if (is_last) {
-		if (!registry.near_map.has(`${array_path_str}${PATH_SEPARATOR}${offset - 1}`)) return false;
-		return registry.edge_map.get(array_path_str)?.last === true;
+		if (!near.has(offset - 1)) return false;
+		return edge_state?.last === true;
 	}
 
-	return (
-		registry.near_map.has(`${array_path_str}${PATH_SEPARATOR}${offset - 1}`) &&
-		registry.near_map.has(`${array_path_str}${PATH_SEPARATOR}${offset}`)
-	);
+	return near.has(offset - 1) && near.has(offset);
 }

--- a/src/test/gap_visibility.svelte.test.js
+++ b/src/test/gap_visibility.svelte.test.js
@@ -218,7 +218,9 @@ describe('NodeGap visibility & placement', () => {
 				last_item_rect: { x: li_rect.x, y: li_rect.y, w: li_rect.width, h: li_rect.height },
 				last_item_in_viewport: li_rect.bottom > 0 && li_rect.top < window.innerHeight,
 				last_gap_prev_is_last_item: last_gap.previousElementSibling === last_item,
-				near_has_last: ctx.visibility_registry.near_map.has(last_item.dataset.path),
+				near_has_last: ctx.visibility_registry
+					.get_array_indices(array_el.dataset.path)
+					.has(items.length - 1),
 				edge_state
 			};
 			expect(last_gap.classList.contains('positioned'), JSON.stringify(diag, null, 2)).toBe(true);
@@ -305,10 +307,11 @@ describe('NodeGap visibility & placement', () => {
 		// NodeArrayProperty's `{#each ... (index)}` keys by index, so a
 		// mid-delete unmounts ONLY the trailing-index element. Surviving
 		// siblings keep their DOM nodes and data-path attributes; their
-		// content shifts but `near_map` entries remain valid. If anyone
-		// ever changes that keying to e.g. `(node.id)`, this invariant
-		// breaks and this test fails — pointing straight at the cause.
-		it('removes only the trailing path from near_map, keeps adjacent gaps positioned', async () => {
+		// content shifts but the near-index entries remain valid. If
+		// anyone ever changes that keying to e.g. `(node.id)`, this
+		// invariant breaks and this test fails — pointing straight at
+		// the cause.
+		it('removes only the trailing index from the near set, keeps adjacent gaps positioned', async () => {
 			// 3 buttons fit the narrow vitest viewport. The mid-delete
 			// invariant holds regardless of overflow, but a non-
 			// overflowing array makes the edge-gap assertions
@@ -321,11 +324,11 @@ describe('NodeGap visibility & placement', () => {
 			expect(array_el.scrollWidth).toBeLessThanOrEqual(array_el.clientWidth + 5);
 
 			const ctx = /** @type {any} */ (globalThis).__svedit_ctx_for_test;
-			const near_map = ctx.visibility_registry.near_map;
 			const array_path = 'page_1__body__0__buttons';
+			const near = ctx.visibility_registry.get_array_indices(array_path);
 
 			for (let i = 0; i < 3; i++) {
-				expect(near_map.has(`${array_path}__${i}`)).toBe(true);
+				expect(near.has(i)).toBe(true);
 			}
 
 			// Delete the button at offset 1 (mid).
@@ -344,13 +347,13 @@ describe('NodeGap visibility & placement', () => {
 
 			expect(session.doc.nodes.story_1.buttons.nodes.length).toBe(2);
 
-			// near_map: __0 and __1 remain (surviving DOM elements
-			// kept their data-path attributes — the element at __1 now
-			// renders what was at __2). __2 is gone (trailing index
-			// unmounted by Svelte's keyed-each-by-index).
-			expect(near_map.has(`${array_path}__0`)).toBe(true);
-			expect(near_map.has(`${array_path}__1`)).toBe(true);
-			expect(near_map.has(`${array_path}__2`)).toBe(false);
+			// Near set: indices 0 and 1 remain (surviving DOM elements
+			// kept their data-path attributes — the element at index 1
+			// now renders what was at index 2). Index 2 is gone (trailing
+			// element unmounted by Svelte's keyed-each-by-index).
+			expect(near.has(0)).toBe(true);
+			expect(near.has(1)).toBe(true);
+			expect(near.has(2)).toBe(false);
 
 			// Edge gaps stay positioned (no overflow → edge_map.first
 			// and .last both true).
@@ -435,7 +438,9 @@ describe('NodeGap visibility & placement', () => {
 			// Guard against the vacuous pass: the last button must still
 			// be near, so the gap's visibility is decided by edge_map.
 			const ctx = /** @type {any} */ (globalThis).__svedit_ctx_for_test;
-			expect(ctx.visibility_registry.near_map.has('page_1__body__0__buttons__2')).toBe(true);
+			expect(ctx.visibility_registry.get_array_indices('page_1__body__0__buttons').has(2)).toBe(
+				true
+			);
 
 			expect(find_first_gap(array_el).classList.contains('positioned')).toBe(true);
 			expect(find_last_gap(array_el).classList.contains('positioned')).toBe(false);


### PR DESCRIPTION
**Stacked on #324** — review that one first; this is a pure refactor on top (no behavior change intended). If both are approved: merge this into #324's branch, then merge #324 into main.

## What

The visibility registry kept node nearness in two stores written together at every site: `near_map` (full path → `true`, read by NodeGap) and the per-array `array_indices` SvelteSets (read by NodeGapMarkers). Every `near_map` read had the form "array path + child index", so both consumers can read the same per-array sets. `near_map` is deleted; `array_indices` is the single source of truth.

This is the same disease #324 treats — two copies of one fact that must be kept in sync — applied to the registry's own internals. It also drops dead state: `near_map` stored entries for nodes that aren't node-array children (document root), which nothing ever read.

## The interesting part: a real Svelte reactivity trap

The naive version of this refactor (calling `registry.get_array_indices(path).has(i)` inside `should_position_gap`) **silently broke the first gap of every array**, caught by the existing test suite. Root cause: `get_array_indices` lazily creates the `SvelteSet`, and Svelte intentionally does not track dependencies on state created inside the currently-evaluating reaction. So the first consumer to touch an array (always the `gap-before`, first in DOM order) created the set inside its own `$derived`, never subscribed, and froze un-positioned forever — while every later gap read the existing set and worked. `NodeGapMarkers` only ever worked because it happens to hold the set in one `$derived` and read it in another.

The fix makes that split explicit and documented:

- `NodeGap` acquires the set in its own `$derived` (`near_indices`) and reads membership in the `positioned` derived — mirroring `NodeGapMarkers`.
- `should_position_gap` is now a **pure function** `(near, edge_state, offset, is_last, empty)` — no registry access, trivially testable.
- `get_array_indices` carries a doc warning that the two-derived split is load-bearing.

## Verified

All suites pass: gap_visibility (16, incl. the HMR repro and the resize test), selection_scroll (6), keymap_continuity (4), Svedit/Session/annotations (93). `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)