### PR TITLE
Eliminate O(N) layout and data-layer costs for large documents

### DIFF
--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -1,0 +1,10 @@
+/**
+ * Enables the JS self-profiling API (used by the perftest lab) on dev-served
+ * pages. Vite's server.headers doesn't apply to SvelteKit-rendered HTML, so
+ * the header is set here.
+ */
+export async function handle({ event, resolve }) {
+	const response = await resolve(event);
+	response.headers.set('Document-Policy', 'js-profiling');
+	return response;
+}

--- a/src/lib/NodeGap.svelte
+++ b/src/lib/NodeGap.svelte
@@ -111,8 +111,29 @@
 	}
 
 	/* ------------------------------------------------------------------ */
-	/* Un-positioned: minimal in-DOM presence, no anchor resolution        */
+	/* Un-positioned: no layout box at all                                 */
 	/* ------------------------------------------------------------------ */
+
+	/*
+	 * display: none is load-bearing for large documents. A zero-size
+	 * absolutely-positioned selectable still belongs to the containing
+	 * block's out-of-flow list, and the browser lays out EVERY such box
+	 * on EVERY layout pass — measured ~430ms per pass at 2000 nodes
+	 * (~3500 gaps) in Chrome vs ~23ms with the boxes removed. That cost
+	 * hits every keystroke (the per-change reconcile reads a rect for
+	 * every node, and selection rendering forces layout), every window
+	 * resize frame, and every scroll-triggered layout.
+	 *
+	 * Off-screen gaps therefore contribute no layout box. DOM structure
+	 * stays stable (the .node-gap wrapper and selectable elements remain),
+	 * and DOM Ranges may still point into display:none elements, so
+	 * programmatic node selections targeting off-screen gaps keep working.
+	 * Empty-array gaps are excluded: they must stay clickable/visible even
+	 * before reconcile positions them.
+	 */
+	:global(.node-gap:not(.positioned):not(.empty) .svedit-selectable) {
+		display: none;
+	}
 
 	:global(.node-gap:not(.positioned) .svedit-selectable) {
 		position: absolute;

--- a/src/lib/Session.svelte.js
+++ b/src/lib/Session.svelte.js
@@ -1,11 +1,12 @@
 import Transaction from './Transaction.svelte.js';
-import { char_slice, traverse } from './utils.js';
+import { char_slice, traverse, traverse_ids } from './utils.js';
 import {
 	get as doc_get,
 	property_type as doc_property_type,
 	kind as doc_kind,
 	inspect as doc_inspect,
-	apply_op,
+	create_document_draft,
+	apply_op_to_draft,
 	count_references as doc_count_references,
 	validate_document_schema,
 	validate_document,
@@ -148,35 +149,33 @@ export default class Session {
 	 */
 	validate_transaction_result(transaction) {
 		const doc = transaction.doc;
-		/** @type {NodeId[]} */
-		const affected_node_ids = [];
+		/** @type {Set<NodeId>} */
+		// eslint-disable-next-line svelte/prefer-svelte-reactivity -- Non-reactive local dedup set.
+		const affected_node_ids = new Set([
+			...transaction.created_node_ids,
+			...transaction.modified_node_ids
+		]);
 
-		function add_node_id(node_id) {
-			if (!affected_node_ids.includes(node_id)) affected_node_ids.push(node_id);
-		}
-
-		for (const node_id of transaction.created_node_ids) add_node_id(node_id);
-		for (const node_id of transaction.modified_node_ids) add_node_id(node_id);
-		for (const node_id of get_referencing_node_ids(
-			this.schema,
-			doc,
-			transaction.created_node_ids
-		)) {
-			add_node_id(node_id);
-		}
-		for (const node_id of get_referencing_node_ids(
-			this.schema,
-			doc,
-			transaction.modified_node_ids
-		)) {
-			add_node_id(node_id);
-		}
-		for (const node_id of get_referencing_node_ids(
-			this.schema,
-			doc,
-			transaction.deleted_node_ids
-		)) {
-			add_node_id(node_id);
+		// A full-document referrer scan is only needed when a reference held
+		// by an UNTOUCHED node can have become invalid:
+		// - deletions can leave dangling references behind
+		// - a 'type' change can violate a referrer's node/mark/annotation type
+		//   constraint
+		// References to created nodes can only live in nodes that were
+		// themselves created or modified in this transaction (the reference
+		// did not exist before), and modifying a node's other properties
+		// cannot invalidate its referrers — so those cases are already
+		// covered by the affected set and need no scan.
+		if (transaction.deleted_node_ids.length > 0 || transaction.changed_node_types) {
+			// eslint-disable-next-line svelte/prefer-svelte-reactivity -- Non-reactive local dedup set.
+			const scan_targets = new Set([
+				...transaction.created_node_ids,
+				...transaction.modified_node_ids,
+				...transaction.deleted_node_ids
+			]);
+			for (const node_id of get_referencing_node_ids(this.schema, doc, scan_targets)) {
+				affected_node_ids.add(node_id);
+			}
 		}
 
 		for (const node_id of affected_node_ids) {
@@ -266,7 +265,13 @@ export default class Session {
 	 */
 	apply(transaction, { batch = false } = {}) {
 		this.validate_transaction_result(transaction);
-		this.doc = transaction.doc;
+		// Only swap the doc when something changed. The transaction draft is
+		// always a fresh object, and assigning it for an ops-less transaction
+		// (e.g. selection-only) would needlessly invalidate every doc-dependent
+		// derived in the component tree.
+		if (transaction.ops.length > 0) {
+			this.doc = transaction.doc;
+		}
 		// Make sure selection gets a new reference (is rerendered)
 		this.selection = structuredClone(transaction.selection);
 		if (this.history_index < this.history.length - 1) {
@@ -315,12 +320,14 @@ export default class Session {
 			return;
 		}
 		const change = this.history[this.history_index];
-		let doc = this.doc;
+		// One draft for the whole change set — ops mutate the draft with
+		// node-level copy-on-write instead of copying the nodes map per op.
+		const doc = create_document_draft(this.doc);
 		change.inverse_ops
 			.slice()
 			.reverse()
 			.forEach((op) => {
-				doc = apply_op(doc, op);
+				apply_op_to_draft(doc, op);
 			});
 		this.doc = doc;
 		this.selection = change.selection_before;
@@ -334,9 +341,9 @@ export default class Session {
 		}
 		this.history_index = this.history_index + 1;
 		const change = this.history[this.history_index];
-		let doc = this.doc;
+		const doc = create_document_draft(this.doc);
 		change.ops.forEach((op) => {
-			doc = apply_op(doc, op);
+			apply_op_to_draft(doc, op);
 		});
 		this.doc = doc;
 		this.selection = change.selection_after;
@@ -542,7 +549,9 @@ export default class Session {
 		const start = Math.min(this.selection.anchor_offset, this.selection.focus_offset);
 		const end = Math.max(this.selection.anchor_offset, this.selection.focus_offset);
 		const node_array = this.get(this.selection.path);
-		return $state.snapshot(node_array.nodes.slice(start, end));
+		// node_array.nodes is a plain array of id strings (doc is $state.raw),
+		// so a slice is already a safe fresh copy.
+		return node_array.nodes.slice(start, end);
 	}
 
 	select_parent() {
@@ -595,7 +604,11 @@ export default class Session {
 	 * @note Nodes that are not reachable from the entry point node will not be included
 	 */
 	traverse(node_id) {
-		return traverse(node_id, this.schema, $state.snapshot(this.doc.nodes));
+		// doc is $state.raw, so doc.nodes is a plain (non-proxied) object —
+		// traverse() reads it directly and deep-clones each visited node.
+		// The previous $state.snapshot(this.doc.nodes) here deep-cloned the
+		// ENTIRE document per call, which made copying M nodes O(M·N).
+		return traverse(node_id, this.schema, this.doc.nodes);
 	}
 
 	/**
@@ -634,9 +647,7 @@ export default class Session {
 	 * @returns {NodeId[]}
 	 */
 	get_referenced_nodes(node_id) {
-		const traversed_nodes = this.traverse(node_id);
-
-		// Extract IDs and exclude the last element (root node)
-		return traversed_nodes.slice(0, -1).map((node) => node.id);
+		// Id-only traversal — no need to deep-clone the subgraph for ids.
+		return traverse_ids(node_id, this.schema, this.doc.nodes).slice(0, -1);
 	}
 }

--- a/src/lib/Svedit.svelte
+++ b/src/lib/Svedit.svelte
@@ -1334,7 +1334,10 @@ ${fallback_html}`;
 			if (!anchor_sel || !focus_sel) return;
 
 			if (is_backward) {
-				dom_selection.removeAllRanges();
+				// setBaseAndExtent replaces the current selection, so no
+				// removeAllRanges is needed — every selection-API call forces a
+				// synchronous layout when the DOM is dirty, and this runs right
+				// after the per-change reconcile on every apply.
 				dom_selection.setBaseAndExtent(anchor_sel, 1, focus_sel, 1);
 			} else {
 				range.setStart(anchor_sel, 1);
@@ -1496,8 +1499,10 @@ ${fallback_html}`;
 
 		// Set the range if both start and end were found
 		if (anchor_node && focus_node) {
-			dom_selection.removeAllRanges();
-			// NOTE: Only using setBaseAndExtent() will preserve selection direction
+			// NOTE: Only using setBaseAndExtent() will preserve selection direction.
+			// It also replaces the current selection, so no removeAllRanges is
+			// needed — every selection-API call forces a synchronous layout when
+			// the DOM is dirty, and this runs on every apply.
 			dom_selection.setBaseAndExtent(
 				anchor_node,
 				anchor_node_offset,

--- a/src/lib/TextProperty.svelte
+++ b/src/lib/TextProperty.svelte
@@ -25,9 +25,10 @@
 	});
 
 	let plain_text = $derived(svedit.session.get(path).content);
-	let is_empty = $derived(
-		get_char_length(plain_text) === 0 && !(svedit.is_composing && is_focused)
-	);
+	// A string has zero grapheme clusters iff it has zero code units, so a
+	// plain length check avoids a full Intl.Segmenter pass (this derived
+	// re-runs for every text property on every document change).
+	let is_empty = $derived(plain_text.length === 0 && !(svedit.is_composing && is_focused));
 
 	let is_collapsed = $derived(
 		is_focused && svedit.session.selection?.anchor_offset == svedit.session.selection?.focus_offset
@@ -65,6 +66,14 @@
 	 * @returns {Array<Fragment>} Array of fragments
 	 */
 	function get_fragments(text, marks, selection_highlight_range) {
+		// Fast path: no marks and no selection highlight means the whole text
+		// is a single content fragment. This runs for EVERY text property on
+		// EVERY document change, so skipping the two full Intl.Segmenter passes
+		// (get_char_length + char_slice over the whole text) matters at scale.
+		if (marks.length === 0 && !selection_highlight_range) {
+			return text.length > 0 ? [text] : [];
+		}
+
 		const ranges = calculate_fragment_ranges(
 			get_char_length(text),
 			marks,

--- a/src/lib/Transaction.svelte.js
+++ b/src/lib/Transaction.svelte.js
@@ -6,6 +6,7 @@ import {
 	get_char_length,
 	char_slice,
 	traverse,
+	traverse_ids,
 	get_selection_range,
 	is_selection_collapsed,
 	adjust_ranges_for_deletion,
@@ -18,8 +19,10 @@ import {
 	property_type as doc_property_type,
 	kind as doc_kind,
 	inspect as doc_inspect,
-	apply_op,
-	count_references_excluding_deleted,
+	create_document_draft,
+	apply_op_to_draft,
+	build_reference_counts,
+	visit_node_references,
 	validate_node,
 	is_id_valid,
 	fill_node_defaults,
@@ -73,8 +76,13 @@ export default class Transaction {
 	 */
 	constructor(schema, doc, selection, config) {
 		this.schema = schema;
+		// The transaction works on a draft: one shallow copy of the nodes map
+		// up front, then ops mutate the draft in place (copying node objects
+		// on write). This keeps the original document untouched and node
+		// identity stable for unchanged nodes, without the previous
+		// one-full-map-copy-per-op cost.
 		/** @type {object} */
-		this.doc = doc;
+		this.doc = create_document_draft(doc);
 		/** @type {Selection} */
 		this.selection = selection;
 		this.config = config;
@@ -92,6 +100,9 @@ export default class Transaction {
 		this.modified_node_ids = [];
 		/** @type {NodeId[]} */
 		this.deleted_node_ids = [];
+		// True when any op set a node's 'type' property — referrers must be
+		// re-validated against type constraints in that case.
+		this.changed_node_types = false;
 	}
 
 	/**
@@ -167,8 +178,7 @@ export default class Transaction {
 	 * @returns {NodeId[]} Array of referenced node IDs
 	 */
 	get_referenced_nodes(node_id) {
-		const traversed_nodes = traverse(node_id, this.schema, this.doc.nodes);
-		return traversed_nodes.slice(0, -1).map((node) => node.id);
+		return traverse_ids(node_id, this.schema, this.doc.nodes).slice(0, -1);
 	}
 
 	/**
@@ -226,7 +236,7 @@ export default class Transaction {
 	 * @private
 	 */
 	_apply_op(op) {
-		this.doc = apply_op(this.doc, op);
+		apply_op_to_draft(this.doc, op);
 	}
 
 	/**
@@ -283,10 +293,11 @@ export default class Transaction {
 			removed_node_ids = [previous_value];
 		} else if (prop_type === 'node_array') {
 			const previous_node_ids = previous_value.nodes;
-			const next_node_ids = value.nodes;
+			// eslint-disable-next-line svelte/prefer-svelte-reactivity -- Non-reactive local lookup set.
+			const next_node_ids = new Set(value.nodes);
 
 			// Only include node IDs that were in previous_value but are not in the new value
-			removed_node_ids = previous_node_ids.filter((id) => !next_node_ids.includes(id));
+			removed_node_ids = previous_node_ids.filter((id) => !next_node_ids.has(id));
 		}
 
 		const op = ['set', normalized_path, value];
@@ -294,6 +305,7 @@ export default class Transaction {
 		this.inverse_ops.push(['set', normalized_path, previous_value]);
 		this._apply_op(op);
 		this._track_node_id(this.modified_node_ids, node.id);
+		if (property_key_str === 'type') this.changed_node_types = true;
 
 		// Garbage-collect nodes whose only reference was via this property.
 		// We must use a ref-count-aware sweep instead of unconditional deletion
@@ -963,6 +975,15 @@ export default class Transaction {
 	 * @private
 	 */
 	_cascade_delete_unreferenced_nodes(potentially_orphaned_nodes) {
+		if (potentially_orphaned_nodes.length === 0) return;
+
+		// Build reference counts in ONE full-document scan, then maintain them
+		// incrementally: marking a node deleted decrements the counts of every
+		// node it references (per occurrence). This replaces the previous
+		// per-candidate full-document re-scan, which made deleting M nodes
+		// O(M·N) instead of O(N + M).
+		const ref_counts = build_reference_counts(this.schema, this.doc);
+
 		/** @type {Record<NodeId, boolean>} */
 		const nodes_to_delete = {};
 		const to_check = [...potentially_orphaned_nodes];
@@ -971,16 +992,20 @@ export default class Transaction {
 			const node_id = to_check.pop();
 			if (!node_id || nodes_to_delete[node_id]) continue;
 
-			// Count references to this node, excluding nodes already marked for deletion
-			const ref_count = this._count_references_excluding_deleted(node_id, nodes_to_delete);
-
-			if (ref_count === 0) {
+			if ((ref_counts.get(node_id) || 0) === 0) {
 				// No more references, safe to delete this node
 				nodes_to_delete[node_id] = true;
 
-				// Also check all nodes referenced by this node
-				const referenced_nodes = this.get_referenced_nodes(node_id);
-				to_check.push(...referenced_nodes);
+				// Release this node's outgoing references and re-check the
+				// nodes it pointed at — they may have become unreferenced.
+				const node = this.doc.nodes[node_id];
+				if (node) {
+					visit_node_references(this.schema, node, (referenced_id) => {
+						const count = ref_counts.get(referenced_id);
+						if (count !== undefined) ref_counts.set(referenced_id, count - 1);
+						to_check.push(referenced_id);
+					});
+				}
 			}
 		}
 
@@ -995,25 +1020,5 @@ export default class Transaction {
 				this._track_node_id(this.deleted_node_ids, node_id);
 			}
 		}
-	}
-
-	/**
-	 * Counts references to a node, excluding nodes that have been marked for deletion.
-	 *
-	 * This is used during cascade deletion to accurately count remaining references
-	 * as nodes are being deleted.
-	 *
-	 * @param {NodeId} target_node_id - The node ID to count references for
-	 * @param {Record<NodeId, boolean>} nodes_to_delete - Nodes already marked for deletion
-	 * @returns {number} The number of references to the target node
-	 * @private
-	 */
-	_count_references_excluding_deleted(target_node_id, nodes_to_delete) {
-		return count_references_excluding_deleted(
-			this.schema,
-			this.doc,
-			target_node_id,
-			nodes_to_delete
-		);
 	}
 }

--- a/src/lib/doc_utils.js
+++ b/src/lib/doc_utils.js
@@ -704,6 +704,53 @@ export function inspect(schema, doc, path) {
 }
 
 /**
+ * Creates a mutable draft of a document: a new document object with a new
+ * nodes map, sharing the (immutable) node objects with the original.
+ *
+ * apply_op_to_draft mutates the draft's nodes map but copies node objects
+ * before changing them, so node identity is preserved for unchanged nodes
+ * (fine-grained rendering relies on this) and the original document is
+ * never touched.
+ *
+ * @param {Document} doc - The document to create a draft of
+ * @returns {Document} A draft document safe to mutate via apply_op_to_draft
+ */
+export function create_document_draft(doc) {
+	return {
+		...doc,
+		nodes: { ...doc.nodes }
+	};
+}
+
+/**
+ * Applies an operation to a document draft in place.
+ *
+ * The draft's nodes map is mutated, but node objects are copied on write —
+ * one nodes-map copy per draft (see create_document_draft) replaces the
+ * previous one-copy-per-op behavior, which made transactions with many ops
+ * (paste, cascade delete) O(N·ops).
+ *
+ * @param {Document} draft - A draft created via create_document_draft
+ * @param {Array} op - The operation to apply [type, ...args]
+ * @returns {Document} The same draft, for convenience
+ */
+export function apply_op_to_draft(draft, op) {
+	const [type, ...args] = op;
+	if (type === 'set') {
+		const [node_id, property] = args[0];
+		draft.nodes[node_id] = {
+			...draft.nodes[node_id],
+			[property]: structuredClone(args[1])
+		};
+	} else if (type === 'create') {
+		draft.nodes[args[0].id] = structuredClone(args[0]);
+	} else if (type === 'delete') {
+		delete draft.nodes[args[0]];
+	}
+	return draft;
+}
+
+/**
  * Applies an operation to a document and returns the new document.
  * Uses copy-on-write semantics.
  *
@@ -712,37 +759,7 @@ export function inspect(schema, doc, path) {
  * @returns {Document} The new document with the operation applied
  */
 export function apply_op(doc, op) {
-	const [type, ...args] = op;
-	if (type === 'set') {
-		const [node_id, property] = args[0];
-		const value = structuredClone(args[1]);
-		return {
-			...doc,
-			nodes: {
-				...doc.nodes,
-				[node_id]: {
-					...doc.nodes[node_id],
-					[property]: value
-				}
-			}
-		};
-	} else if (type === 'create') {
-		return {
-			...doc,
-			nodes: {
-				...doc.nodes,
-				[args[0].id]: structuredClone(args[0])
-			}
-		};
-	} else if (type === 'delete') {
-		// eslint-disable-next-line
-		const { [args[0]]: _removed, ...remaining_nodes } = doc.nodes;
-		return {
-			...doc,
-			nodes: remaining_nodes
-		};
-	}
-	return doc;
+	return apply_op_to_draft(create_document_draft(doc), op);
 }
 
 /**
@@ -904,6 +921,60 @@ export function count_references_excluding_deleted(schema, doc, target_node_id, 
 	}
 
 	return count;
+}
+
+/**
+ * Iterates all node references going out of a node, invoking the visitor
+ * once per occurrence (multiplicity matters for reference counting).
+ * Covers the same reference kinds as count_references_excluding_deleted:
+ * a `node` property, `node_array` .nodes ids, and the mark/annotation
+ * node_ids carried on `text` and `node_array` properties.
+ *
+ * @param {DocumentSchema} schema - The document schema
+ * @param {any} node - The node whose outgoing references to visit
+ * @param {(referenced_id: NodeId) => void} visit - Called per reference occurrence
+ */
+export function visit_node_references(schema, node, visit) {
+	const node_schema = schema[node.type];
+	if (!node_schema) return;
+
+	for (const [property, prop_def] of Object.entries(node_schema.properties)) {
+		const value = node[property];
+		if (value === undefined || value === null) continue;
+
+		const prop_type = prop_def.type;
+
+		if (prop_type === 'node_array') {
+			for (const id of value.nodes) visit(id);
+		} else if (prop_type === 'node' && typeof value === 'string') {
+			visit(value);
+		}
+
+		if ((prop_type === 'text' || prop_type === 'node_array') && value) {
+			for (const range of value.marks) visit(range.node_id);
+			for (const range of value.annotations) visit(range.node_id);
+		}
+	}
+}
+
+/**
+ * Builds reference counts for every referenced node in one full-document
+ * scan. Used by cascade deletion so the fixpoint can decrement counts
+ * incrementally instead of re-scanning the document per candidate node.
+ *
+ * @param {DocumentSchema} schema - The document schema
+ * @param {Document} doc - The document containing nodes
+ * @returns {Map<NodeId, number>} Reference count per referenced node id
+ */
+export function build_reference_counts(schema, doc) {
+	/** @type {Map<NodeId, number>} */
+	const counts = new Map();
+	for (const node of Object.values(doc.nodes)) {
+		visit_node_references(schema, node, (id) => {
+			counts.set(id, (counts.get(id) || 0) + 1);
+		});
+	}
+	return counts;
 }
 
 /**

--- a/src/lib/node_visibility.svelte.js
+++ b/src/lib/node_visibility.svelte.js
@@ -362,13 +362,11 @@ class VisibilityRegistry {
 		const path = /** @type {HTMLElement} */ (array_el).dataset.path;
 		if (!path) return false;
 
-		const sl = array_el.scrollLeft;
-		const sw = array_el.scrollWidth;
-		const cw = array_el.clientWidth;
-		const st = array_el.scrollTop;
-		const sh = array_el.scrollHeight;
-		const ch = array_el.clientHeight;
-
+		// Check computed overflow BEFORE touching scroll metrics. Reading
+		// scrollLeft/scrollWidth forces a synchronous layout when the DOM is
+		// dirty, while getComputedStyle only forces style recalc. Non-clipping
+		// arrays — the common case (a plain column body) — resolve to
+		// first=last=true without any scroll-metric read.
 		const style = getComputedStyle(array_el);
 		const clips_x = style.overflowX !== 'visible';
 		const clips_y = style.overflowY !== 'visible';
@@ -377,10 +375,18 @@ class VisibilityRegistry {
 		// Normal wrapping/grid node arrays often have harmless layout overflow
 		// (scrollWidth > clientWidth) while overflow remains visible; treating
 		// that as scroll position would incorrectly hide edge gaps.
-		const first = (!clips_x || sl <= EDGE_TOLERANCE_PX) && (!clips_y || st <= EDGE_TOLERANCE_PX);
-		const last =
-			(!clips_x || sl + cw >= sw - EDGE_TOLERANCE_PX) &&
-			(!clips_y || st + ch >= sh - EDGE_TOLERANCE_PX);
+		let first = true;
+		let last = true;
+		if (clips_x) {
+			const sl = array_el.scrollLeft;
+			first = sl <= EDGE_TOLERANCE_PX;
+			last = sl + array_el.clientWidth >= array_el.scrollWidth - EDGE_TOLERANCE_PX;
+		}
+		if (clips_y) {
+			const st = array_el.scrollTop;
+			first = first && st <= EDGE_TOLERANCE_PX;
+			last = last && st + array_el.clientHeight >= array_el.scrollHeight - EDGE_TOLERANCE_PX;
+		}
 
 		return untrack(() => {
 			const prev = this.edge_map.get(path);

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -404,6 +404,51 @@ export function paths_equal(a, b) {
 	return a.every((segment, index) => segment === b[index]);
 }
 
+/**
+ * Like traverse, but returns only node ids in depth-first order and never
+ * clones nodes. Use this when only the reachable id set is needed (e.g.
+ * reference bookkeeping) — traverse() deep-clones every visited node,
+ * which is wasteful for id-only consumers.
+ *
+ * @param {string} node_id - The ID of the node to start traversing from
+ * @param {object} schema - The document schema
+ * @param {Record<string, any>} nodes - All document nodes
+ * @returns {string[]} Node ids in depth-first order (entry point last)
+ */
+export function traverse_ids(node_id, schema, nodes) {
+	const ids = [];
+	const visited = {};
+	const visit = (node) => {
+		if (!node || visited[node.id]) {
+			return;
+		}
+		visited[node.id] = true;
+		for (const [property_name, value] of Object.entries(node)) {
+			const property_definition = schema[node.type].properties[property_name];
+
+			if (property_definition?.type === 'node_array') {
+				for (const v of value?.nodes || []) {
+					if (typeof v === 'string') {
+						visit(nodes[v]);
+					}
+				}
+				for (const range of [...(value?.marks || []), ...(value?.annotations || [])]) {
+					visit(nodes[range.node_id]);
+				}
+			} else if (property_definition?.type === 'node') {
+				visit(nodes[value]);
+			} else if (property_definition?.type === 'text') {
+				for (const range of [...(value.marks || []), ...(value.annotations || [])]) {
+					visit(nodes[range.node_id]);
+				}
+			}
+		}
+		ids.push(node.id);
+	};
+	visit(nodes[node_id]);
+	return ids;
+}
+
 export function traverse(node_id, schema, nodes) {
 	const json = [];
 	const visited = {};

--- a/src/routes/perftest/+page.svelte
+++ b/src/routes/perftest/+page.svelte
@@ -3,6 +3,21 @@
 	import { Svedit, Session, KeyMapper } from 'svedit';
 	import { document_schema, session_config } from '../create_demo_session.js';
 	import nanoid from '../nanoid.js';
+	import {
+		install_instrumentation,
+		timings_reset,
+		timings_get,
+		bench_enter,
+		bench_type,
+		bench_paste,
+		bench_copy,
+		bench_delete,
+		bench_undo,
+		bench_resize_layout,
+		profile
+	} from './bench.js';
+
+	install_instrumentation();
 
 	const PRESETS = [50, 100, 200, 500, 1000, 2000];
 
@@ -10,6 +25,8 @@
 	let editable = $state(true);
 	let mount_key = $state(0);
 	let editor_wrapper;
+	let svedit_ref;
+	let culling = $state(true);
 
 	let live_fps = $state(0);
 	let live_memory = $state(null);
@@ -128,7 +145,7 @@
 	}
 
 	function make_session() {
-		const config = { ...session_config };
+		const config = { ...session_config, visibility_culling: culling };
 		const doc = generate_document(node_count);
 		const s = new Session(document_schema, doc, config);
 		return s;
@@ -136,16 +153,51 @@
 
 	let session = $state(make_session());
 
+	// rAF that also resolves in hidden tabs (rAF never fires there).
+	function next_frame() {
+		return new Promise((resolve) => {
+			const id = requestAnimationFrame(() => {
+				clearTimeout(timer);
+				resolve(undefined);
+			});
+			const timer = setTimeout(() => {
+				cancelAnimationFrame(id);
+				resolve(undefined);
+			}, 32);
+		});
+	}
+
 	async function apply_settings() {
 		const t0 = performance.now();
 		session = make_session();
 		mount_key++;
 		await tick();
-		await new Promise((r) => requestAnimationFrame(r));
-		await new Promise((r) => requestAnimationFrame(r));
+		await next_frame();
+		await next_frame();
 		render_ms = Math.round(performance.now() - t0);
 		await new Promise((r) => setTimeout(r, 100));
 		snap_counts();
+	}
+
+	function bench_ctx() {
+		return {
+			session,
+			focus: () => svedit_ref?.focus_canvas()
+		};
+	}
+
+	/** @param {number} n */
+	async function set_nodes(n) {
+		node_count = n;
+		await apply_settings();
+	}
+
+	/** @param {{ nodes?: number, editable?: boolean, culling?: boolean }} opts */
+	async function set_state(opts = {}) {
+		if (typeof opts.nodes === 'number') node_count = opts.nodes;
+		if (typeof opts.editable === 'boolean') editable = opts.editable;
+		if (typeof opts.culling === 'boolean') culling = opts.culling;
+		await apply_settings();
 	}
 
 	function snap_counts() {
@@ -449,13 +501,31 @@
 			run_full_benchmark,
 			apply_settings,
 			run_matrix_test,
+			set_nodes,
+			set_state,
 			get results() {
 				return benchmark_results;
+			},
+			get session() {
+				return session;
 			}
+		};
+		/** @type {any} */ (window).__bench = {
+			enter: (/** @type {number} */ count) => bench_enter(bench_ctx(), count),
+			type: (/** @type {number} */ count) => bench_type(bench_ctx(), count),
+			paste: (/** @type {number} */ m, /** @type {any} */ mode) => bench_paste(bench_ctx(), m, mode),
+			copy: (/** @type {number} */ m) => bench_copy(bench_ctx(), m),
+			del: (/** @type {number} */ m) => bench_delete(bench_ctx(), m),
+			undo: () => bench_undo(bench_ctx()),
+			resize: (/** @type {number} */ steps) => bench_resize_layout({ wrapper: editor_wrapper }, steps),
+			profile,
+			timings_reset,
+			timings_get
 		};
 		return () => {
 			cancelAnimationFrame(raf_id);
 			delete (/** @type {any} */ (window).__perf);
+			delete (/** @type {any} */ (window).__bench);
 		};
 	});
 </script>
@@ -584,7 +654,7 @@
 
 <div class="editor-area" bind:this={editor_wrapper}>
 	{#key mount_key}
-		<Svedit {session} bind:editable path={[session.doc.document_id]} />
+		<Svedit bind:this={svedit_ref} {session} bind:editable path={[session.doc.document_id]} />
 	{/key}
 </div>
 

--- a/src/routes/perftest/bench.js
+++ b/src/routes/perftest/bench.js
@@ -1,0 +1,456 @@
+/**
+ * Editing benchmarks and timing instrumentation for the perftest page.
+ *
+ * Instrumentation wraps Session/Transaction prototype methods with wall-time
+ * accumulators so end-to-end benchmark numbers can be attributed to specific
+ * internals without touching library code. Note: timings are total (inclusive)
+ * time per method — nested calls are counted in their parents too.
+ *
+ * Data model note: on this base a `text` property is `{content, marks,
+ * annotations}` and a `node_array` property is `{nodes, marks, annotations}`.
+ */
+
+import { tick } from 'svelte';
+import { Session, Transaction } from 'svedit';
+
+/** @type {Record<string, { calls: number, ms: number }>} */
+let timings = {};
+
+let instrumented = false;
+
+/**
+ * @param {any} proto
+ * @param {string} name
+ * @param {string} label
+ */
+function wrap_method(proto, name, label) {
+	const original = proto[name];
+	if (typeof original !== 'function') return;
+	proto[name] = function (...args) {
+		const t0 = performance.now();
+		try {
+			return original.apply(this, args);
+		} finally {
+			const entry = (timings[label] ??= { calls: 0, ms: 0 });
+			entry.calls += 1;
+			entry.ms += performance.now() - t0;
+		}
+	};
+}
+
+export function install_instrumentation() {
+	if (instrumented || typeof window === 'undefined') return;
+	instrumented = true;
+	wrap_method(Session.prototype, 'get', 'session.get');
+	wrap_method(Session.prototype, 'inspect', 'session.inspect');
+	wrap_method(Session.prototype, 'apply', 'session.apply');
+	wrap_method(Session.prototype, 'validate_transaction_result', 'session.validate_transaction_result');
+	wrap_method(Session.prototype, 'traverse', 'session.traverse');
+	wrap_method(Session.prototype, 'undo', 'session.undo');
+	wrap_method(Transaction.prototype, '_apply_op', 'tr._apply_op');
+	wrap_method(Transaction.prototype, 'set', 'tr.set');
+	wrap_method(Transaction.prototype, 'create', 'tr.create');
+	wrap_method(Transaction.prototype, 'delete', 'tr.delete');
+	wrap_method(Transaction.prototype, 'build', 'tr.build');
+	wrap_method(Transaction.prototype, '_cascade_delete_unreferenced_nodes', 'tr._cascade_delete');
+}
+
+export function timings_reset() {
+	timings = {};
+}
+
+export function timings_get() {
+	/** @type {Record<string, { calls: number, ms: number }>} */
+	const out = {};
+	for (const [key, value] of Object.entries(timings)) {
+		out[key] = { calls: value.calls, ms: Math.round(value.ms * 100) / 100 };
+	}
+	return out;
+}
+
+/**
+ * Resolve on the next animation frame, falling back to a timeout when the
+ * tab is hidden (rAF never fires there). Frame timings are only meaningful
+ * when the tab is visible — use force_layout for deterministic layout cost.
+ */
+function next_frame() {
+	return new Promise((resolve) => {
+		const id = requestAnimationFrame(() => {
+			clearTimeout(timer);
+			resolve('raf');
+		});
+		const timer = setTimeout(() => {
+			cancelAnimationFrame(id);
+			resolve('timeout');
+		}, 32);
+	});
+}
+
+/**
+ * Force a synchronous full-document layout and return its duration in ms.
+ * Works in hidden tabs (layout is computed on demand; only paint is skipped).
+ */
+function force_layout() {
+	const t0 = performance.now();
+	void document.documentElement.offsetHeight;
+	return performance.now() - t0;
+}
+
+/** @param {number[]} values */
+function stats(values) {
+	if (values.length === 0) return { avg: 0, p50: 0, p95: 0, max: 0 };
+	const sorted = [...values].sort((a, b) => a - b);
+	const sum = sorted.reduce((acc, value) => acc + value, 0);
+	const pick = (/** @type {number} */ q) =>
+		sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * q))];
+	const round = (/** @type {number} */ value) => Math.round(value * 100) / 100;
+	return {
+		avg: round(sum / sorted.length),
+		p50: round(pick(0.5)),
+		p95: round(pick(0.95)),
+		max: round(sorted[sorted.length - 1])
+	};
+}
+
+/**
+ * @param {any} session
+ * @returns {number} index of the last text-kind node in the document body
+ */
+function last_text_node_index(session) {
+	const body = session.get([session.document_id, 'body']).nodes;
+	for (let i = body.length - 1; i >= 0; i--) {
+		if (session.kind(session.get(body[i])) === 'text') return i;
+	}
+	throw new Error('No text node found in body');
+}
+
+/**
+ * Put a collapsed text caret at the end of the last text node in the body.
+ * @param {any} session
+ */
+function place_caret_in_last_text_node(session) {
+	const index = last_text_node_index(session);
+	const path = [session.document_id, 'body', index, 'content'];
+	const text = session.get(path).content;
+	// Offsets are grapheme-based; ASCII fixture text means length is fine.
+	session.selection = {
+		type: 'text',
+		path,
+		anchor_offset: text.length,
+		focus_offset: text.length
+	};
+	return path;
+}
+
+/**
+ * Simulate holding Enter: repeatedly execute the break_text_node command,
+ * exactly like the keymap does on a real keydown.
+ *
+ * @param {{ session: any, focus: () => void }} ctx
+ * @param {number} count
+ */
+export async function bench_enter(ctx, count = 20) {
+	const { session } = ctx;
+	ctx.focus();
+	place_caret_in_last_text_node(session);
+	await tick();
+
+	const data_ms = [];
+	const render_ms = [];
+	const layout_ms = [];
+	const t_start = performance.now();
+	for (let i = 0; i < count; i++) {
+		const t0 = performance.now();
+		session.commands.break_text_node.execute();
+		const t1 = performance.now();
+		await tick();
+		const t2 = performance.now();
+		layout_ms.push(force_layout());
+		data_ms.push(t1 - t0);
+		render_ms.push(t2 - t1);
+	}
+	return {
+		op: 'enter',
+		count,
+		total_ms: Math.round(performance.now() - t_start),
+		data: stats(data_ms),
+		render: stats(render_ms),
+		layout: stats(layout_ms)
+	};
+}
+
+/**
+ * Simulate fast typing: insert one character per iteration via insert_text,
+ * like onbeforeinput does.
+ *
+ * @param {{ session: any, focus: () => void }} ctx
+ * @param {number} count
+ */
+export async function bench_type(ctx, count = 30) {
+	const { session } = ctx;
+	ctx.focus();
+	place_caret_in_last_text_node(session);
+	await tick();
+
+	const data_ms = [];
+	const render_ms = [];
+	const layout_ms = [];
+	const t_start = performance.now();
+	for (let i = 0; i < count; i++) {
+		const t0 = performance.now();
+		const tr = session.tr;
+		tr.insert_text('x');
+		session.apply(tr, { batch: true });
+		const t1 = performance.now();
+		await tick();
+		const t2 = performance.now();
+		layout_ms.push(force_layout());
+		data_ms.push(t1 - t0);
+		render_ms.push(t2 - t1);
+	}
+	return {
+		op: 'type',
+		count,
+		total_ms: Math.round(performance.now() - t_start),
+		data: stats(data_ms),
+		render: stats(render_ms),
+		layout: stats(layout_ms)
+	};
+}
+
+/** @param {number} m */
+function make_paste_payload(m) {
+	/** @type {Record<string, any>} */
+	const nodes = {};
+	const main_nodes = [];
+	for (let i = 0; i < m; i++) {
+		const id = `paste_src_${i}`;
+		nodes[id] = {
+			id,
+			type: 'paragraph',
+			content: {
+				content: `Pasted paragraph ${i + 1}. Lorem ipsum dolor sit amet, consectetur adipiscing elit sed do eiusmod.`,
+				marks: [],
+				annotations: []
+			}
+		};
+		main_nodes.push(id);
+	}
+	return { nodes, main_nodes };
+}
+
+/**
+ * Simulate pasting m text nodes, replicating the node-paste data path
+ * (tr.build per node + insert_nodes + apply).
+ *
+ * @param {{ session: any, focus: () => void }} ctx
+ * @param {number} m
+ * @param {'append' | 'replace'} mode - replace selects the first m nodes first
+ */
+export async function bench_paste(ctx, m = 100, mode = 'append') {
+	const { session } = ctx;
+	ctx.focus();
+	const body_path = [session.document_id, 'body'];
+	const body_length = session.get(body_path).nodes.length;
+	session.selection =
+		mode === 'replace'
+			? { type: 'node', path: body_path, anchor_offset: 0, focus_offset: Math.min(m, body_length) }
+			: { type: 'node', path: body_path, anchor_offset: body_length, focus_offset: body_length };
+	await tick();
+
+	const { nodes, main_nodes } = make_paste_payload(m);
+	const t0 = performance.now();
+	const tr = session.tr;
+	const nodes_to_insert = [];
+	for (const node_id of main_nodes) {
+		nodes_to_insert.push(tr.build(node_id, nodes));
+	}
+	tr.insert_nodes(nodes_to_insert);
+	session.apply(tr);
+	const t1 = performance.now();
+	await tick();
+	const t2 = performance.now();
+	const layout = force_layout();
+	return {
+		op: `paste_${mode}`,
+		m,
+		data_ms: Math.round(t1 - t0),
+		render_ms: Math.round(t2 - t1),
+		layout_ms: Math.round(layout)
+	};
+}
+
+/**
+ * Simulate copying m nodes, replicating the copy path
+ * (session.traverse per selected node).
+ *
+ * @param {{ session: any, focus: () => void }} ctx
+ * @param {number} m
+ */
+export async function bench_copy(ctx, m = 100) {
+	const { session } = ctx;
+	ctx.focus();
+	const body_path = [session.document_id, 'body'];
+	const body_length = session.get(body_path).nodes.length;
+	session.selection = {
+		type: 'node',
+		path: body_path,
+		anchor_offset: 0,
+		focus_offset: Math.min(m, body_length)
+	};
+	await tick();
+
+	const t0 = performance.now();
+	const selected_node_ids = session.get_selected_nodes();
+	/** @type {Record<string, any>} */
+	const nodes = {};
+	for (const node_id of selected_node_ids) {
+		const subgraph = session.traverse(node_id);
+		for (const node of subgraph) {
+			if (!nodes[node.id]) nodes[node.id] = node;
+		}
+	}
+	const t1 = performance.now();
+	return {
+		op: 'copy',
+		m,
+		payload_nodes: Object.keys(nodes).length,
+		data_ms: Math.round(t1 - t0)
+	};
+}
+
+/**
+ * Simulate deleting m selected nodes (cut without clipboard).
+ *
+ * @param {{ session: any, focus: () => void }} ctx
+ * @param {number} m
+ */
+export async function bench_delete(ctx, m = 100) {
+	const { session } = ctx;
+	ctx.focus();
+	const body_path = [session.document_id, 'body'];
+	const body_length = session.get(body_path).nodes.length;
+	session.selection = {
+		type: 'node',
+		path: body_path,
+		anchor_offset: 0,
+		focus_offset: Math.min(m, body_length)
+	};
+	await tick();
+
+	const t0 = performance.now();
+	session.apply(session.tr.delete_selection());
+	const t1 = performance.now();
+	await tick();
+	const t2 = performance.now();
+	const layout = force_layout();
+	return {
+		op: 'delete',
+		m,
+		data_ms: Math.round(t1 - t0),
+		render_ms: Math.round(t2 - t1),
+		layout_ms: Math.round(layout)
+	};
+}
+
+/**
+ * Undo the last change (interesting after paste/delete — replays inverse ops).
+ *
+ * @param {{ session: any }} ctx
+ */
+export async function bench_undo(ctx) {
+	const { session } = ctx;
+	const t0 = performance.now();
+	session.undo();
+	const t1 = performance.now();
+	await tick();
+	const t2 = performance.now();
+	const layout = force_layout();
+	return {
+		op: 'undo',
+		data_ms: Math.round(t1 - t0),
+		render_ms: Math.round(t2 - t1),
+		layout_ms: Math.round(layout)
+	};
+}
+
+/**
+ * Run a function under the JS self-profiling API and return top stack frames
+ * by sample count. Requires the Document-Policy: js-profiling header.
+ *
+ * @param {() => Promise<any>} fn
+ * @param {number} top - how many frames to report
+ */
+export async function profile(fn, top = 30) {
+	const ProfilerCtor = /** @type {any} */ (window).Profiler;
+	if (!ProfilerCtor) return { error: 'Profiler API unavailable (missing js-profiling document policy?)' };
+	const profiler = new ProfilerCtor({ sampleInterval: 1, maxBufferSize: 1_000_000 });
+	const result = await fn();
+	const trace = await profiler.stop();
+
+	const self_counts = new Map();
+	const total_counts = new Map();
+	const frame_name = (/** @type {number} */ frame_id) => {
+		const frame = trace.frames[frame_id];
+		if (!frame) return '(unknown)';
+		const resource = frame.resourceId !== undefined ? trace.resources[frame.resourceId] : '';
+		const file = resource ? String(resource).split('/').slice(-1)[0].split('?')[0] : '';
+		return `${frame.name || '(anonymous)'} [${file}:${frame.line ?? '?'}]`;
+	};
+	for (const sample of trace.samples) {
+		if (sample.stackId === undefined) continue;
+		let stack_id = sample.stackId;
+		let leaf = true;
+		const seen = new Set();
+		while (stack_id !== undefined) {
+			const node = trace.stacks[stack_id];
+			if (!node) break;
+			const name = frame_name(node.frameId);
+			if (leaf) {
+				self_counts.set(name, (self_counts.get(name) || 0) + 1);
+				leaf = false;
+			}
+			if (!seen.has(name)) {
+				seen.add(name);
+				total_counts.set(name, (total_counts.get(name) || 0) + 1);
+			}
+			stack_id = node.parentId;
+		}
+	}
+	const to_sorted = (/** @type {Map<string, number>} */ map) =>
+		[...map.entries()]
+			.sort((a, b) => b[1] - a[1])
+			.slice(0, top)
+			.map(([name, count]) => ({ name, samples: count }));
+	return {
+		result,
+		total_samples: trace.samples.length,
+		self: to_sorted(self_counts),
+		total: to_sorted(total_counts)
+	};
+}
+
+/**
+ * Measure synchronous relayout cost while alternating the editor wrapper
+ * width — a deterministic proxy for window-resize cost that also works in
+ * hidden tabs. Each step invalidates layout and forces a full reflow.
+ *
+ * @param {{ wrapper: HTMLElement }} ctx
+ * @param {number} steps
+ */
+export async function bench_resize_layout(ctx, steps = 20) {
+	const wrapper = ctx.wrapper;
+	if (!wrapper) throw new Error('No editor wrapper');
+	const layout_ms = [];
+	await next_frame();
+	force_layout();
+	for (let i = 0; i < steps; i++) {
+		wrapper.style.maxWidth = i % 2 === 0 ? '700px' : '1100px';
+		layout_ms.push(force_layout());
+		// Yield so style recalc doesn't coalesce across iterations.
+		await new Promise((resolve) => setTimeout(resolve, 0));
+	}
+	wrapper.style.maxWidth = '';
+	force_layout();
+	return { op: 'resize_layout', steps, layout: stats(layout_ms) };
+}


### PR DESCRIPTION
Makes large documents (500–5000+ nodes) fast by **eliminating** costly per-operation work — no caches or derived state added, only better algorithms and fewer forced layouts.

## Root cause

The dominant cost wasn't JS — it was **layout**. Every off-screen `NodeGap` kept a zero-size `position:absolute` selectable, and the browser re-lays-out every out-of-flow box on every layout pass (~430ms per pass at 2000 nodes, ~3500 gaps). Since the per-change `reconcile()` reads a rect for every node and selection rendering forces layout, this throttled typing, Enter, resize, and scroll alike. On top of that, the data layer did full-document scans/clones per operation.

Found and measured with a small perftest lab (`/perftest`, `window.__bench`) added here.

## Changes

**Layout**
- `NodeGap`: unpositioned non-empty gap selectables are `display:none` — off-screen gaps contribute no layout box (~430ms → ~23ms per full layout at 2000 nodes). DOM structure and range read-back are preserved; empty-array gaps excluded.
- `Svedit`: drop redundant `removeAllRanges()` before `setBaseAndExtent` (it already replaces the selection; each selection call forces layout).
- `node_visibility.sync_edge_state`: check computed overflow before reading scroll metrics so non-clipping arrays don't force layout.
- `TextProperty`: fast path for unannotated text (skips two `Intl.Segmenter` passes per property per change); length-based `is_empty`.

**Data layer**
- `doc_utils`: `create_document_draft` + `apply_op_to_draft` — one nodes-map copy per transaction/undo/redo with node-level copy-on-write, replacing the per-op full-map copy. New `visit_node_references` / `build_reference_counts`.
- `Transaction`: draft-based apply; Set-based removed-id diff (was O(N²)); single-scan cascade GC with incremental decrement (was a full scan per candidate); `changed_node_types` flag; `traverse_ids` for reference walks.
- `Session`: `validate_transaction_result` does at most one referrer scan (only on delete or type change); draft-based undo/redo; `traverse` no longer snapshots the whole doc; ops-less apply keeps the doc reference.
- `utils`: `traverse_ids` (id-only, clone-free traversal).

All reference kinds of the current model are handled: `node`, `node_array.nodes`, and mark **and** annotation `node_id`s on both `text` and `node_array`.

## Results (Chrome, dev)

| Operation | Before | After |
|---|---|---|
| Copy 200 nodes (2000-doc) | 2420 ms | **2 ms** |
| Delete 200 nodes, data (2000) | 604 ms | **20 ms** |
| Enter render (500 / 1000 / 2000) | 88 / 329 / 1615 ms | **51 / 131 / 374 ms** |
| Type render (2000) | 1324 ms | **123 ms** |
| Full relayout / resize step (2000) | 438 ms | **23 ms** |

Residual per-keystroke cost is the unavoidable `setBaseAndExtent` layout — the browser's floor for this DOM size.

## Verification

21 in-browser correctness checks pass, including mark-node and annotation-node cascade deletion, undo/redo of cascades, split/join, and validation still rejecting invalid input. Production build and lint are clean.

## Notes for review

- Off-screen gaps are no longer native arrow-key stops (they previously rendered an *invisible* caret with no marker, so arguably a fix) — worth a feel-check on horizontally-scrolling arrays.
- Docs passed to `Session` must be plain objects (they are in this repo); `traverse`/copy would throw on a `$state`-proxied doc now that the per-call full-doc snapshot is gone.
- Scroll/resize **FPS** wasn't measured here (the lab ran in a headless tab); a quick check in a visible browser at 1000+ nodes is worthwhile.
- `src/routes/perftest/*` + `src/hooks.server.js` are the measurement lab; drop them from the merge if you'd rather not ship the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)