### PR TITLE
Guard against null focusNode in deferred scroll-into-view

### DIFF
--- a/src/lib/Svedit.svelte
+++ b/src/lib/Svedit.svelte
@@ -1505,9 +1505,12 @@ ${fallback_html}`;
 				focus_node_offset
 			);
 
-			// Scroll the selection into view
+			// Scroll the selection into view. Deferred a tick, so focus may have
+			// left the canvas by now (e.g. into a form input or dialog), which
+			// clears the document selection and leaves focusNode null. Nothing to
+			// scroll to in that case.
 			setTimeout(() => {
-				const selectedElement = dom_selection.focusNode.parentElement;
+				const selectedElement = dom_selection.focusNode?.parentElement;
 				if (selectedElement) {
 					selectedElement.scrollIntoView({ block: 'nearest', inline: 'nearest' });
 				}


### PR DESCRIPTION
**What happens**

`render_selection` sets the DOM selection, then scrolls it into view a tick later:

```js
setTimeout(() => {
	const selectedElement = dom_selection.focusNode.parentElement; // throws
	...
}, 0);
```

If focus leaves the canvas before that timeout fires (e.g. into a form `<input>` in a toolbar or dialog), the browser clears the document selection, so `dom_selection.focusNode` is `null` and `.parentElement` throws:

```
Uncaught TypeError: Cannot read properties of null (reading 'parentElement')
```

**Not a DOM-stability issue.** Logged at the throw site: the intended `focus_node` is still `isConnected`, `getSelection().type === 'None'`, and `activeElement` is the input. Nothing re-rendered out from under the selection; the selection just moved to the input.

**Repro:** select text, focus an `<input>` outside the canvas (a link editor, etc.), then click back into the text.

**Fix:** optional-chain the `focusNode` read. A deferred read of the live `Selection` can't assume `focusNode` still exists, and if the selection has left the canvas there is nothing to scroll to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
