### PR TITLE
Fix deferred selection scroll after focus moves

### DIFF
--- a/src/lib/Svedit.svelte
+++ b/src/lib/Svedit.svelte
@@ -1510,11 +1510,13 @@ ${fallback_html}`;
 				focus_node_offset
 			);
 
-			// Scroll the selection into view
+			// Scroll the rendered selection into view. Capture the target now:
+			// the browser selection is live and may be cleared before this
+			// deferred callback runs, e.g. when app UI focuses an external input.
+			const selected_element = focus_node.parentElement;
 			setTimeout(() => {
-				const selectedElement = dom_selection.focusNode.parentElement;
-				if (selectedElement) {
-					selectedElement.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+				if (selected_element?.isConnected) {
+					selected_element.scrollIntoView({ block: 'nearest', inline: 'nearest' });
 				}
 			}, 0);
 		}

--- a/src/test/Svedit.svelte.test.js
+++ b/src/test/Svedit.svelte.test.js
@@ -2,11 +2,51 @@ import { describe, it, expect } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { tick } from 'svelte';
 import SveditTest from './testing_components/SveditTest.svelte';
+import SveditTestWithInput from './testing_components/SveditTestWithInput.svelte';
 import create_test_session from './create_test_session.js';
 import { join_text_node } from '../lib/transforms.svelte.js';
 import nanoid from '../routes/nanoid.js';
 
 describe('Svedit.svelte', () => {
+	it('does not throw when focus leaves the canvas before deferred text-selection scroll runs', async () => {
+		const session = create_test_session();
+		const errors = [];
+		const on_error = (event) => {
+			if (String(event.error?.message ?? event.message).includes('parentElement')) {
+				errors.push(event.error ?? event.message);
+				event.preventDefault();
+			}
+		};
+		window.addEventListener('error', on_error);
+
+		try {
+			const { container } = render(SveditTestWithInput, { session });
+			const canvas = /** @type {HTMLElement} */ (container.querySelector('.svedit-canvas'));
+			const input = /** @type {HTMLInputElement} */ (
+				container.querySelector('[data-testid="external-input"]')
+			);
+
+			canvas.focus();
+			await tick();
+
+			session.selection = {
+				type: 'text',
+				path: ['page_1', 'body', 0, 'title'],
+				anchor_offset: 0,
+				focus_offset: 5
+			};
+			await tick();
+
+			input.focus();
+			window.getSelection()?.removeAllRanges();
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			expect(errors).toEqual([]);
+		} finally {
+			window.removeEventListener('error', on_error);
+		}
+	});
+
 	it('should map node caret to DOM', async () => {
 		const session = create_test_session();
 

--- a/src/test/testing_components/SveditTestWithInput.svelte
+++ b/src/test/testing_components/SveditTestWithInput.svelte
@@ -1,0 +1,11 @@
+<script>
+	import Svedit from '../../lib/Svedit.svelte';
+	import Layout from '../../routes/components/Layout.svelte';
+
+	let { session } = $props();
+</script>
+
+<Layout>
+	<Svedit {session} editable={true} path={[session.doc.document_id]} />
+	<input data-testid="external-input" aria-label="External input" />
+</Layout>


### PR DESCRIPTION
Capture the rendered text-selection scroll target before the deferred scrollIntoView callback runs. This avoids reading the live browser Selection after focus has moved to external UI, where focusNode may be cleared.

Add a regression test for changing Svedit selection, focusing an external
input in the same tick, and clearing the document selection before the deferred scroll runs.