### PR TITLE
Move test options under test in the vitest config

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -10,9 +10,11 @@ export default defineConfig({
 			enabled: true,
 			// at least one instance is required
 			instances: [{ browser: 'chromium' }]
-		}
-	},
-	clearMocks: true,
-	include: ['src/**/*.svelte.{test,spec}.{js,ts}'],
-	exclude: ['src/lib/server/**']
+		},
+		// include is a test option — vitest ignores it at the config top
+		// level. Anchored to src/ so stray test-file copies (e.g. under
+		// .claude/worktrees/) never enter the run.
+		include: ['src/**/*.svelte.{test,spec}.{js,ts}'],
+		clearMocks: true
+	}
 });


### PR DESCRIPTION
include, exclude and clearMocks are test options; at the config top level vitest ignores them and falls back to its defaults. The default include pattern matches the whole project, so test-file copies outside src/ (e.g. under .claude/worktrees/) were collected into runs.

- include now anchors collection to src/
- clearMocks now actually applies (no current test uses mocks, so behavior is unchanged today)
- the src/lib/server/** exclude is dropped: the directory doesn't exist, and leaving exclude untouched keeps vitest's default excludes (node_modules, .git) intact