### PR TITLE
Close the typing batch window on undo and redo

### DIFF
--- a/src/lib/Session.svelte.ts
+++ b/src/lib/Session.svelte.ts
@@ -256,7 +256,7 @@ export default class Session<S extends DocumentSchema = DocumentSchema> {
 
 	/**
 	 * Applies a transaction to the document.
-	 * Auto-batches history entries with debounced behavior (max one entry per 2 seconds) when batch is true.
+	 * Auto-batches history entries with debounced behavior (max one entry per second) when batch is true.
 	 *
 	 * @param transaction - The transaction to apply
 	 * @param options - Optional configuration (batch: whether to allow batching with previous transaction)
@@ -283,7 +283,7 @@ export default class Session<S extends DocumentSchema = DocumentSchema> {
 			now - this.last_batch_started < BATCH_WINDOW_MS;
 
 		if (should_batch) {
-			// Append to existing history entry (within 2s of batch start)
+			// Append to existing history entry (within the batch window)
 			const last_entry = this.history[this.history_index];
 			last_entry.ops.push(...transaction.ops);
 			last_entry.inverse_ops.push(...transaction.inverse_ops);
@@ -291,7 +291,7 @@ export default class Session<S extends DocumentSchema = DocumentSchema> {
 			// Trigger update
 			this.history = [...this.history];
 		} else {
-			// Create new history entry (more than 2s since batch started, or first edit, or batch not requested)
+			// Create new history entry (batch window elapsed, first edit, or batch not requested)
 			this.history = [
 				...this.history,
 				{
@@ -330,6 +330,9 @@ export default class Session<S extends DocumentSchema = DocumentSchema> {
 		this.doc = doc;
 		this.selection = change.selection_before;
 		this.history_index = this.history_index - 1;
+		// History navigation ends any open typing batch, so the next batched
+		// apply starts a fresh entry instead of appending to a stale one.
+		this.last_batch_started = undefined;
 		return this;
 	}
 
@@ -345,6 +348,8 @@ export default class Session<S extends DocumentSchema = DocumentSchema> {
 		});
 		this.doc = doc;
 		this.selection = change.selection_after;
+		// Redo ends any open typing batch, matching undo().
+		this.last_batch_started = undefined;
 		return this;
 	}
 

--- a/src/test/batch_window.svelte.test.ts
+++ b/src/test/batch_window.svelte.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import create_test_session from './create_test_session.js';
+
+function set_title_caret(session: ReturnType<typeof create_test_session>, offset: number) {
+	session.selection = {
+		type: 'text',
+		path: ['story_1', 'title'],
+		anchor_offset: offset,
+		focus_offset: offset
+	};
+}
+
+function type_char(session: ReturnType<typeof create_test_session>, char: string) {
+	const tr = session.tr;
+	tr.insert_text(char);
+	session.apply(tr, { batch: true });
+}
+
+describe('batch window after undo/redo', () => {
+	it('does not crash when a batched apply follows an undo within the batch window', () => {
+		const session = create_test_session();
+		set_title_caret(session, 11);
+
+		type_char(session, 'a');
+		session.undo();
+		type_char(session, 'b');
+
+		expect(session.get<{ content: string }>(['story_1', 'title']).content).toBe('First storyb');
+		expect(session.history.length).toBe(1);
+	});
+
+	it('starts a new entry when typing continues after a redo', () => {
+		const session = create_test_session();
+		set_title_caret(session, 11);
+
+		type_char(session, 'a');
+		session.undo();
+		session.redo();
+		type_char(session, 'b');
+
+		// 'b' must not merge into the redone 'a' entry.
+		expect(session.get<{ content: string }>(['story_1', 'title']).content).toBe('First storyab');
+		expect(session.history.length).toBe(2);
+	});
+});


### PR DESCRIPTION
Reproducible on main: type a character (batched), press undo, type again within one second → `TypeError: Cannot read properties of undefined (reading 'ops')`. After an undo, the batching slot at `history[history_index]` is stale or gone entirely (the index may be -1 once the redo tail is truncated) while `last_batch_started` is still open. When the slot still exists, new typing silently merges into a history entry it doesn't belong to, corrupting undo granularity.

Undo and redo now close the batch window, so typing after history navigation always starts a fresh entry. Two regression tests included (the first was verified failing before the fix).

Also aligns the batching comments with `BATCH_WINDOW_MS` (1 second); they still said 2 seconds.

This is the base branch for the op-engine series proposed in #335.

🤖 Generated with [Claude Code](https://claude.com/claude-code)