### PR TITLE
Decouple selection rendering from scrolling

### DIFF
--- a/src/lib/Svedit.svelte
+++ b/src/lib/Svedit.svelte
@@ -59,6 +59,12 @@
 	let is_composing = $state(false);
 	let canvas_focused = $state(false);
 	let before_composition_selection: TextSelection | null = null;
+	// Selection restoration and selection revealing are separate concerns.
+	// DOM changes (for example, toggling an annotation) can require rebuilding
+	// the native selection even when the logical selection did not move. Keep
+	// the last selection rendered while focused so those rebuilds do not also
+	// move the viewport.
+	let last_rendered_selection_snapshot: string | null = null;
 	// Set by onselectionchange before it commits a DOM-derived selection
 	// to the model. render_selection consumes-and-clears it to skip
 	// rerender on DOM-driven changes (the DOM is already in place).
@@ -849,7 +855,7 @@ ${fallback_html}`;
 		}
 	}
 
-	function render_selection(dom_driven = false) {
+	function render_selection(dom_driven = false, should_scroll_selection_into_view = true) {
 		const selection = session.selection as Selection;
 
 		if (!selection) {
@@ -879,11 +885,11 @@ ${fallback_html}`;
 		}
 
 		if (selection?.type === 'text') {
-			__render_text_selection();
+			__render_text_selection(should_scroll_selection_into_view);
 		} else if (selection?.type === 'node') {
-			__render_node_selection();
+			__render_node_selection(should_scroll_selection_into_view);
 		} else if (selection?.type === 'property') {
-			__render_property_selection();
+			__render_property_selection(should_scroll_selection_into_view);
 		} else {
 			console.warn('unsupported selection', $state.snapshot(selection));
 		}
@@ -1285,7 +1291,7 @@ ${fallback_html}`;
 		return r.bottom > 0 && r.top < window.innerHeight && r.right > 0 && r.left < window.innerWidth;
 	}
 
-	function __render_node_selection() {
+	function __render_node_selection(should_scroll_selection_into_view = true) {
 		const selection = session.selection as NodeSelection;
 		const node_array_path = selection.path;
 		const node_array_path_str = serialize_path(node_array_path);
@@ -1336,6 +1342,7 @@ ${fallback_html}`;
 				dom_selection.addRange(range);
 			}
 		}
+		if (!should_scroll_selection_into_view) return;
 
 		// Scroll the cursor into view, but only when it is genuinely
 		// off-screen. This runs on every node-selection re-render — a
@@ -1399,7 +1406,7 @@ ${fallback_html}`;
 		}, 0);
 	}
 
-	function __render_property_selection() {
+	function __render_property_selection(should_scroll_selection_into_view = true) {
 		const selection = session.selection;
 		// The element that holds the property
 		const el = canvas_el.querySelector<HTMLElement>(
@@ -1416,13 +1423,14 @@ ${fallback_html}`;
 		dom_selection.removeAllRanges();
 		dom_selection.addRange(range);
 
-		// Scroll the selection into view
-		setTimeout(() => {
-			el.scrollIntoView({ block: 'nearest', inline: 'nearest' });
-		}, 0);
+		if (should_scroll_selection_into_view) {
+			setTimeout(() => {
+				el.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+			}, 0);
+		}
 	}
 
-	function __render_text_selection() {
+	function __render_text_selection(should_scroll_selection_into_view = true) {
 		const selection = session.selection as TextSelection;
 		// The element that holds the annotated string
 		const el = canvas_el.querySelector<HTMLElement>(
@@ -1512,15 +1520,17 @@ ${fallback_html}`;
 				focus_node_offset
 			);
 
-			// Scroll the rendered selection into view. Capture the target now:
-			// the browser selection is live and may be cleared before this
-			// deferred callback runs, e.g. when app UI focuses an external input.
-			const selected_element = focus_node.parentElement;
-			setTimeout(() => {
-				if (selected_element?.isConnected) {
-					selected_element.scrollIntoView({ block: 'nearest', inline: 'nearest' });
-				}
-			}, 0);
+			if (should_scroll_selection_into_view) {
+				// Scroll the rendered selection into view. Capture the target now:
+				// the browser selection is live and may be cleared before this
+				// deferred callback runs, e.g. when app UI focuses an external input.
+				const selected_element = focus_node.parentElement;
+				setTimeout(() => {
+					if (selected_element?.isConnected) {
+						selected_element.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+					}
+				}, 0);
+			}
 		}
 	}
 
@@ -1611,7 +1621,11 @@ ${fallback_html}`;
 		const dom_driven = selection_source_is_dom;
 		selection_source_is_dom = false;
 		if (!canvas_focused) return;
-		render_selection(dom_driven);
+		const selection_snapshot = JSON.stringify(session.selection);
+		const should_scroll_selection_into_view =
+			selection_snapshot !== last_rendered_selection_snapshot;
+		render_selection(dom_driven, should_scroll_selection_into_view);
+		last_rendered_selection_snapshot = selection_snapshot;
 	});
 </script>
 

--- a/src/lib/Svedit.svelte
+++ b/src/lib/Svedit.svelte
@@ -1623,7 +1623,7 @@ ${fallback_html}`;
 		if (!canvas_focused) return;
 		const selection_snapshot = JSON.stringify(session.selection);
 		const should_scroll_selection_into_view =
-			selection_snapshot !== last_rendered_selection_snapshot;
+			!dom_driven && selection_snapshot !== last_rendered_selection_snapshot;
 		render_selection(dom_driven, should_scroll_selection_into_view);
 		last_rendered_selection_snapshot = selection_snapshot;
 	});

--- a/src/test/Svedit.svelte.test.ts
+++ b/src/test/Svedit.svelte.test.ts
@@ -8,6 +8,54 @@ import { join_text_node } from '../lib/transforms.svelte.js';
 import nanoid from '../routes/nanoid.js';
 
 describe('Svedit.svelte', () => {
+	it('does not scroll when the user selects text after a non-text selection', async () => {
+		const session = create_test_session();
+		const tr = session.tr;
+		tr.set(['story_1', 'title'], { content: '', marks: [], annotations: [] });
+		session.apply(tr);
+
+		const { container } = render(SveditTest, { session });
+		await tick();
+		const canvas = container.querySelector('.svedit-canvas') as HTMLElement;
+		session.selection = {
+			type: 'property',
+			path: ['page_1', 'body', 0, 'image']
+		};
+		canvas.focus();
+		await tick();
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		const text_el = container.querySelector<HTMLElement>(
+			'[data-path="page_1__body__0__title"][data-type="text"]'
+		);
+		expect(text_el).not.toBeNull();
+		const scroll_into_view = vi.spyOn(Element.prototype, 'scrollIntoView');
+
+		try {
+			// Simulate the browser placing a caret after a tap. Empty text is
+			// significant: it must be reconstructed rather than taking the
+			// normal DOM-selection-match shortcut.
+			const range = document.createRange();
+			range.setStart(text_el, 1);
+			range.collapse(true);
+			window.getSelection()?.removeAllRanges();
+			window.getSelection()?.addRange(range);
+			document.dispatchEvent(new Event('selectionchange'));
+			await tick();
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			expect(session.selection).toMatchObject({
+				type: 'text',
+				path: ['page_1', 'body', 0, 'title'],
+				anchor_offset: 0,
+				focus_offset: 0
+			});
+			expect(scroll_into_view).not.toHaveBeenCalled();
+		} finally {
+			scroll_into_view.mockRestore();
+		}
+	});
+
 	it('restores an unchanged property selection without scrolling', async () => {
 		const session = create_test_session();
 		const { container } = render(SveditTest, { session });

--- a/src/test/Svedit.svelte.test.ts
+++ b/src/test/Svedit.svelte.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { tick } from 'svelte';
 import SveditTest from './testing_components/SveditTest.svelte';
@@ -8,6 +8,36 @@ import { join_text_node } from '../lib/transforms.svelte.js';
 import nanoid from '../routes/nanoid.js';
 
 describe('Svedit.svelte', () => {
+	it('restores an unchanged property selection without scrolling', async () => {
+		const session = create_test_session();
+		const { container } = render(SveditTest, { session });
+		await tick();
+		const canvas = container.querySelector('.svedit-canvas') as HTMLElement;
+		const scroll_into_view = vi.spyOn(Element.prototype, 'scrollIntoView');
+
+		try {
+			canvas.focus();
+			session.selection = {
+				type: 'property',
+				path: ['page_1', 'body', 0, 'image']
+			};
+			await tick();
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			scroll_into_view.mockClear();
+
+			// Applying a transaction creates a fresh selection reference, even
+			// when the logical selection is unchanged.
+			session.apply(session.tr);
+			await tick();
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			expect(window.getSelection()?.rangeCount).toBe(1);
+			expect(scroll_into_view).not.toHaveBeenCalled();
+		} finally {
+			scroll_into_view.mockRestore();
+		}
+	});
+
 	it('does not throw when focus leaves the canvas before deferred text-selection scroll runs', async () => {
 		const session = create_test_session();
 		const errors = [];

--- a/src/test/annotations.svelte.test.ts
+++ b/src/test/annotations.svelte.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { tick } from 'svelte';
 import create_test_session from './create_test_session.js';
@@ -48,6 +48,15 @@ function text_selection(anchor_offset: number, focus_offset: number) {
 	return {
 		type: 'text' as const,
 		path: title_path,
+		anchor_offset,
+		focus_offset
+	};
+}
+
+function rendered_title_selection(anchor_offset: number, focus_offset: number) {
+	return {
+		type: 'text' as const,
+		path: ['page_1', 'body', 0, 'title'],
 		anchor_offset,
 		focus_offset
 	};
@@ -244,6 +253,56 @@ describe('mark toggle selection semantics', () => {
 });
 
 describe('annotation toggle selection semantics', () => {
+	it('restores an unchanged text selection without scrolling after an annotation toggle', async () => {
+		const session = create_annotation_session();
+		const { container } = render(SveditTest, { session });
+		await tick();
+		const canvas = container.querySelector('.svedit-canvas') as HTMLElement;
+		const scroll_into_view = vi.spyOn(Element.prototype, 'scrollIntoView');
+
+		try {
+			canvas.focus();
+			session.selection = rendered_title_selection(0, 5);
+			await tick();
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			scroll_into_view.mockClear();
+
+			session.apply(session.tr.toggle_annotation('comment'));
+			await tick();
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			expect(window.getSelection()?.toString()).toBe('First');
+			expect(scroll_into_view).not.toHaveBeenCalled();
+		} finally {
+			scroll_into_view.mockRestore();
+		}
+	});
+
+	it('still scrolls when the logical text selection moves', async () => {
+		const session = create_annotation_session();
+		const { container } = render(SveditTest, { session });
+		await tick();
+		const canvas = container.querySelector('.svedit-canvas') as HTMLElement;
+		const scroll_into_view = vi.spyOn(Element.prototype, 'scrollIntoView');
+
+		try {
+			canvas.focus();
+			session.selection = rendered_title_selection(0, 5);
+			await tick();
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			scroll_into_view.mockClear();
+
+			session.selection = rendered_title_selection(6, 11);
+			await tick();
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			expect(window.getSelection()?.toString()).toBe('story');
+			expect(scroll_into_view).toHaveBeenCalledOnce();
+		} finally {
+			scroll_into_view.mockRestore();
+		}
+	});
+
 	it('creates and removes same-type annotations without stacking', () => {
 		const session = create_annotation_session();
 		create_annotation(session, 'comment', text_selection(0, 5));


### PR DESCRIPTION
The underlying issue is that “restore the browser selection” and “scroll the selection into view” were treated as one operation.

Svedit stores selections in its model, but also needs a native browser selection in the rendered DOM. When the document changes—such as when an annotation wraps text in new elements—the browser selection may point at DOM nodes that no longer exist. Svedit therefore rerenders the native selection after every transaction.

Previously, every restoration also called `scrollIntoView()`. That is appropriate when the logical selection moved—for example after typing, undo, or keyboard navigation—but not when an annotation merely changed the surrounding DOM. In that case the user’s selection stayed in the same place, so scrolling was an unintended side effect.

The new approach remembers the last logical selection that was rendered:

```ts
const should_scroll_selection_into_view =
	selection_snapshot !== last_rendered_selection_snapshot;
```

Svedit still reconstructs the native selection every time it needs to. It passes `should_scroll_selection_into_view` to the text, node, or property selection renderer, and those renderers skip only their scrolling step when the logical selection is unchanged.

This is preferable to checking whether the selection currently intersects the viewport because it addresses intent:

- Same selection, different DOM: restore it without moving the viewport.
- Different selection: restore it and bring it into view.

A viewport check only masks the visible symptom. It can also be wrong for nested scroll containers, partially visible ranges, and selections whose focus endpoint is offscreen.

So the invariant becomes: rendering keeps the browser selection synchronized with the model; scrolling happens only when the model selection actually moves.