### PR TITLE
Node Gap Tools: a snippet for custom tools that should render in the node gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@ const session_config = {
 - **`system_components`** - Optional overrides for internal editor components and a slot for your own overlays:
   - `overlays` — A Svelte component rendered inside `<Svedit>` but outside the content canvas. Use it to add floating UI like link editors, image toolbars, or annotation popovers that appear near the current selection. See [`src/routes/components/Overlays.svelte`](src/routes/components/Overlays.svelte) for an example.
   - `node_gap`, `node_gap_markers`, `node_selection_markers` — Override the default system components if you need custom visuals for node gaps or selection indicators.
+  - `node_gap_tools` — A component rendered inside the active node gap marker, next to the caret. Use it for gap-scoped tools like an insert button: it inherits the `--row` orientation variable from the node array, and it appears and disappears together with the caret. Receives `{ path, offset, is_first, is_last }` (see the `NodeGapToolsProps` type). The marker has `pointer-events: none`, so interactive tools must set `pointer-events: auto`. See [`src/routes/components/GapInsertTool.svelte`](src/routes/components/GapInsertTool.svelte) for an example.
 - **`inserters`** - Functions that create blank nodes of each type and set up the selection
 - **`create_commands_and_keymap`** - Factory function that creates commands and keybindings for an editor instance
 - **`handle_image_paste`** - Optional handler for image paste events

--- a/src/lib/NodeGapMarkers.svelte
+++ b/src/lib/NodeGapMarkers.svelte
@@ -27,11 +27,20 @@
 	 * Reads visibility state directly from the registry. SvelteSet's per-key
 	 * tracking on `.has()` and iteration means this component only
 	 * re-evaluates when THIS array's visible-index set changes.
+	 *
+	 * The active marker (the one carrying the caret) additionally renders the
+	 * consumer's `system_components.node_gap_tools` component when configured
+	 * — an extension point for gap-scoped tools (e.g. an insert button).
+	 * Rendering inside the marker means the tool inherits --row for
+	 * orientation-aware styling and shows/hides together with the caret.
+	 * The marker has pointer-events: none — interactive tools must set
+	 * pointer-events: auto themselves.
 	 */
 
 	let { path, count }: { path: DocumentPath; count: number } = $props();
 
 	const svedit = getContext<SveditRenderContext>('svedit');
+	let NodeGapTools = $derived(svedit.session.config.system_components?.node_gap_tools);
 	let path_str = $derived(serialize_path(path));
 	let visible = $derived(svedit.visibility_registry.get_array_indices(path_str));
 
@@ -163,6 +172,9 @@
 	>
 		{#if gap.key === caret_gap_key}
 			<NodeCaret />
+			{#if NodeGapTools}
+				<NodeGapTools {path} offset={gap.offset} is_first={gap.is_first} is_last={gap.is_last} />
+			{/if}
 		{/if}
 	</div>
 {/each}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -54,6 +54,7 @@ export type {
 	TextPropertyProps,
 	CustomPropertyProps,
 	NodeArrayPropertyProps,
+	NodeGapToolsProps,
 	NodeProps,
 	NodeArrayAttachmentContext
 } from './types.js';

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -459,6 +459,24 @@ export type NodeArrayPropertyProps = {
 };
 
 /**
+ * Props passed to the consumer's `system_components.node_gap_tools`
+ * component. It renders inside the active node gap marker (the one carrying
+ * the caret), so it inherits the `--row` orientation variable and
+ * appears/disappears together with the caret. The marker has
+ * pointer-events: none — interactive tools must set pointer-events: auto.
+ */
+export type NodeGapToolsProps = {
+	/** The full path to the node_array the gap belongs to */
+	path: DocumentPath;
+	/** The insertion offset of the gap (0..count) */
+	offset: number;
+	/** True for the gap before the first node */
+	is_first: boolean;
+	/** True for the gap after the last node */
+	is_last: boolean;
+};
+
+/**
  * Props for the Node component
  */
 export type NodeProps = {

--- a/src/routes/components/GapInsertTool.svelte
+++ b/src/routes/components/GapInsertTool.svelte
@@ -1,0 +1,134 @@
+<script lang="ts">
+	import type { NodeGapToolsProps } from 'svedit';
+	import { get_svedit_context } from '../svedit_context.js';
+
+	/**
+	 * Insert button rendered inside the active node gap marker (registered
+	 * via system_components.node_gap_tools). Because it lives inside the
+	 * marker it inherits --row from the node array, shows/hides together
+	 * with the caret, and positioning next to the gap is local CSS.
+	 */
+	const svedit = get_svedit_context();
+
+	let { path, is_last }: NodeGapToolsProps = $props();
+
+	// Default node_type for the node_array this gap belongs to — mirrors the
+	// bottom toolbar's insert tool, but derived from the gap's own path
+	// instead of the current selection.
+	let default_node_type = $derived.by(() => {
+		const node_array_node = svedit.session.get(path.slice(0, -1));
+		const node_array_property = path.at(-1);
+
+		const node_schema = svedit.session.schema[node_array_node?.type];
+		if (!node_schema) return null;
+
+		const property_definition = node_schema.properties[node_array_property];
+		if (property_definition?.type !== 'node_array') return null;
+
+		return (
+			property_definition.default_node_type ||
+			(property_definition.node_types?.length === 1 ? property_definition.node_types[0] : null)
+		);
+	});
+
+	let inserter = $derived(
+		default_node_type ? svedit.session.config.inserters?.[default_node_type] : null
+	);
+
+	function insert_default_node(event: Event) {
+		// Keep canvas focus and the gap selection while the button is pressed
+		event.preventDefault();
+		if (!inserter) return;
+		const tr = svedit.session.tr;
+		inserter(tr);
+		svedit.session.apply(tr);
+	}
+</script>
+
+{#if inserter}
+	<button
+		class="gap-insert-tool"
+		class:last={is_last}
+		title="Insert (↵)"
+		onmousedown={insert_default_node}
+	>
+		<svg viewBox="0 0 15 15" fill="none" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+			<path d="M7.5 3V12M3 7.5H12" stroke="currentColor" stroke-linecap="square" />
+		</svg>
+	</button>
+{/if}
+
+<style>
+	/* Positioned relative to the gap marker it renders inside. The marker
+	   hugs the gap in both row and column flow, so no anchor positioning is
+	   needed here. Default: centered above the gap. The marker has
+	   pointer-events: none, so re-enable them on the button. */
+	.gap-insert-tool {
+		position: absolute;
+		pointer-events: auto;
+		bottom: calc(100% + var(--s-1));
+		left: 50%;
+		translate: -50% 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		box-sizing: border-box;
+		width: 44px;
+		height: 44px;
+		padding: 0;
+		border: 1px solid oklch(from var(--app-primary-text) l c h / 0.12);
+		border-radius: 50%;
+		background: var(--app-canvas-fill);
+		color: var(--app-primary-text);
+		box-shadow:
+			0 1px 2px oklch(0% 0 0 / 0.12),
+			0 4px 16px oklch(0% 0 0 / 0.08);
+		cursor: pointer;
+		transition:
+			background 150ms,
+			transform 150ms;
+	}
+
+	/* Last gap in column flow: below the gap instead of above */
+	.gap-insert-tool.last {
+		bottom: auto;
+		top: calc(100% + var(--s-1));
+	}
+
+	/* Last gap in row flow (--row: 1): right of the gap, vertically centered */
+	@container style(--row: 1) {
+		.gap-insert-tool.last {
+			top: 50%;
+			left: calc(100% + var(--s-1));
+			translate: 0 -50%;
+		}
+	}
+
+	.gap-insert-tool svg {
+		width: 24px;
+		height: 24px;
+	}
+
+	@media (hover: hover) {
+		.gap-insert-tool:hover {
+			background: oklch(from var(--app-canvas-fill) calc(l - 0.03) c h);
+		}
+	}
+
+	.gap-insert-tool:active {
+		transform: translateY(1px) scale(0.95);
+	}
+
+	.gap-insert-tool:focus-visible {
+		outline: none;
+		box-shadow: inset 0 0 0 1px var(--svedit-editing-stroke);
+	}
+
+	/* Touch devices use the insert button in the bottom toolbar instead,
+	   matching how the floating toolbar is handled. */
+	@media (hover: none), (pointer: coarse) {
+		.gap-insert-tool {
+			display: none;
+		}
+	}
+</style>

--- a/src/routes/components/Toolbar.svelte
+++ b/src/routes/components/Toolbar.svelte
@@ -174,7 +174,6 @@
 	let floating_anchor = $derived.by(
 		(): {
 			name: string;
-			placement: 'above' | 'below';
 			last_node_anchor?: string;
 		} | null => {
 			if (!editable) return null;
@@ -188,11 +187,11 @@
 				// When the selection touches a link mark, the link popover owns
 				// this spot (same pill, same anchor) — the toolbar yields.
 				if (active_link_mark) return null;
-				return { name: serialize_path(sel.path), placement: 'above' };
+				return { name: serialize_path(sel.path) };
 			}
 
 			if (sel.type === 'property') {
-				return { name: serialize_path(sel.path), placement: 'above' };
+				return { name: serialize_path(sel.path) };
 			}
 
 			if (sel.type === 'node') {
@@ -204,26 +203,14 @@
 					// last one when above the first overflows.
 					return {
 						name: serialize_path([...sel.path, start]),
-						placement: 'above',
 						...(end - start > 1 ? { last_node_anchor: serialize_path([...sel.path, end - 1]) } : {})
 					};
 				}
-				// Node caret: the floating toolbar only offers insertion there, so
-				// skip it entirely when nothing can be inserted at this gap.
-				if (!can_insert_default) return null;
-				// Anchor to the node after the caret so the toolbar sits at the
-				// gap. At the end of the array anchor to the node before the
-				// caret and place the toolbar below it instead.
-				const node_array = session.get(sel.path) as { nodes: unknown[] };
-				const node_count = node_array.nodes.length;
-				if (start < node_count) {
-					return { name: serialize_path([...sel.path, start]), placement: 'above' };
-				}
-				if (node_count > 0) {
-					return { name: serialize_path([...sel.path, node_count - 1]), placement: 'below' };
-				}
-				// Empty node arrays render a placeholder carrying the anchor for index 0
-				return { name: serialize_path([...sel.path, 0]), placement: 'above' };
+				// Node caret: insertion is offered by the in-gap tool
+				// (system_components.node_gap_tools → GapInsertTool), which
+				// renders inside the active gap marker — not by the floating
+				// toolbar.
+				return null;
 			}
 
 			return null;
@@ -484,18 +471,14 @@
 	onpointercancel={handle_window_pointerup}
 />
 
-<!-- The drag gate only matters while a pointer drag is building a range;
-     a node gap click sets a caret on pointer down and must show its insert
-     tool instantly, without waiting for pointer up. -->
-{#if floating_anchor && (!is_dragging || is_node_caret)}
+{#if floating_anchor && !is_dragging}
 	<!-- Re-mount the toolbar whenever the anchor changes: swapping
 	     position-anchor on a persistent fixed element can leave it at the
 	     stale position of the previous anchor. -->
-	{#key `${floating_anchor.name}:${floating_anchor.placement}`}
+	{#key floating_anchor.name}
 		<!-- svelte-ignore a11y_no_static_element_interactions -->
 		<div
 			class="editor-toolbar floating-toolbar"
-			class:anchor-below={floating_anchor.placement === 'below'}
 			class:has-last-node-anchor={Boolean(floating_anchor.last_node_anchor)}
 			style="position-anchor: --{floating_anchor.name};{floating_anchor.last_node_anchor
 				? ` --last-selected-node-anchor: --${floating_anchor.last_node_anchor};`
@@ -504,8 +487,8 @@
 		>
 			<div class="toolbar-scroller">
 				<!-- Only the tools that belong to the current selection context: text
-				     selections get text tools, node gaps just the insert button, node
-				     and property selections the node tools. -->
+				     selections get text tools, node and property selections the node
+				     tools. Node carets are handled by GapInsertTool instead. -->
 				{#if selection_type === 'text'}
 					{@render select_parent_button()}
 					{@render mark_buttons()}
@@ -513,8 +496,6 @@
 					{#if show_link_input}
 						{@render contextual_inputs()}
 					{/if}
-				{:else if is_node_caret}
-					{@render insert_button()}
 				{:else if selection_type === 'node'}
 					{@render select_parent_button()}
 					{@render node_mark_buttons()}
@@ -691,13 +672,6 @@
 
 	.floating-toolbar.has-last-node-anchor {
 		position-try-fallbacks: --below-last-node, --stay-in-viewport, flip-block;
-	}
-
-	.floating-toolbar.anchor-below {
-		bottom: auto;
-		top: anchor(bottom);
-		margin-bottom: 0;
-		margin-top: var(--s-2);
 	}
 
 	/* The floating toolbar targets precise mouse interactions. On touch

--- a/src/routes/demo_config.ts
+++ b/src/routes/demo_config.ts
@@ -17,6 +17,7 @@ import { document_schema } from './demo_schema.js';
 import nanoid from './nanoid.js';
 
 import Overlays from './components/Overlays.svelte';
+import GapInsertTool from './components/GapInsertTool.svelte';
 import Page from './components/Page.svelte';
 import Story from './components/Story.svelte';
 import Button from './components/Button.svelte';
@@ -47,9 +48,11 @@ export const app_config = {
 	// Custom ID generator function
 	generate_id: nanoid,
 	// Provide overrides for system components (node_gap, node_gap_markers,
-	// node_selection_markers) or user-land overlays (link previews, etc.)
+	// node_selection_markers), user-land overlays (link previews, etc.) or
+	// gap-scoped tools (node_gap_tools, rendered inside the active gap marker)
 	system_components: {
-		overlays: Overlays
+		overlays: Overlays,
+		node_gap_tools: GapInsertTool
 	},
 	// Registry of components for each node type
 	node_components: {


### PR DESCRIPTION
It becomes quite complicated trying to render custom tools in or near node gaps, because they are not part of the hierarchy (usually they are top level), so straightforward css inheritance e.g. of `--row:1 or 0` for placement optimisation is not possible.

This PR changes that by making it possible to configure a component via `node_gap_tools` that renders in the snippet inside NodeGap.

4x more LOC in core lib.