### PR TITLE
Cull anchor-name registration by viewport proximity while editing

### DIFF
--- a/src/lib/CustomProperty.svelte
+++ b/src/lib/CustomProperty.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { getContext } from 'svelte';
 	import { paths_equal, serialize_path } from './utils.js';
-	import { split_property_path_str } from './node_visibility.svelte.js';
+	import { create_anchor_gate } from './node_visibility.svelte.js';
 	import type { CustomPropertyProps, SveditRenderContext } from './types.js';
 
 	const svedit = getContext<SveditRenderContext>('svedit');
@@ -16,29 +16,17 @@
 	}: CustomPropertyProps = $props();
 	let path_str = $derived(serialize_path(path));
 
-	// Anchor culling, same design as NodeGap's `.positioned` and Node's
-	// `anchored` (see the comment there): while editable, only custom
-	// properties whose owning node is near the viewport register their
-	// `anchor-name`. A property targeted by the current property
-	// selection always keeps its anchor, since the selection overlay
-	// (NodeSelectionMarkers) anchors to it. View mode is unchanged.
-	// Two-derived split: acquire the set here, read in `anchored`.
 	let is_selected = $derived(
 		svedit.session.selection?.type === 'property' &&
 			paths_equal(path, svedit.session.selection.path)
 	);
-	let owner_split = $derived(split_property_path_str(path_str));
-	let near_indices = $derived(
-		owner_split ? svedit.visibility_registry?.get_array_indices(owner_split.array_path) : null
+	// The selected property keeps its anchor: the selection overlay targets it.
+	const anchor = create_anchor_gate(
+		svedit,
+		() => path_str,
+		'property',
+		() => is_selected
 	);
-	let anchored = $derived(
-		!svedit.editable ||
-			is_selected ||
-			!owner_split ||
-			!near_indices ||
-			near_indices.has(owner_split.index)
-	);
-	let anchor_style = $derived(anchored ? `anchor-name: --${path_str};` : '');
 </script>
 
 <svelte:element
@@ -46,7 +34,7 @@
 	class={css_class}
 	data-type="property"
 	data-path={path_str}
-	style="{anchor_style}{style ? ` ${style}` : ''}"
+	style="{anchor.style}{style ? ` ${style}` : ''}"
 	{...rest}
 >
 	<div class="property-selectable">

--- a/src/lib/CustomProperty.svelte
+++ b/src/lib/CustomProperty.svelte
@@ -1,10 +1,44 @@
 <script lang="ts">
-	import { serialize_path } from './utils.js';
-	import type { CustomPropertyProps } from './types.js';
+	import { getContext } from 'svelte';
+	import { paths_equal, serialize_path } from './utils.js';
+	import { split_property_path_str } from './node_visibility.svelte.js';
+	import type { CustomPropertyProps, SveditRenderContext } from './types.js';
 
-	let { path, tag = 'div', class: css_class, children, style, ...rest }: CustomPropertyProps = $props();
+	const svedit = getContext<SveditRenderContext>('svedit');
+
+	let {
+		path,
+		tag = 'div',
+		class: css_class,
+		children,
+		style,
+		...rest
+	}: CustomPropertyProps = $props();
 	let path_str = $derived(serialize_path(path));
 
+	// Anchor culling, same design as NodeGap's `.positioned` and Node's
+	// `anchored` (see the comment there): while editable, only custom
+	// properties whose owning node is near the viewport register their
+	// `anchor-name`. A property targeted by the current property
+	// selection always keeps its anchor, since the selection overlay
+	// (NodeSelectionMarkers) anchors to it. View mode is unchanged.
+	// Two-derived split: acquire the set here, read in `anchored`.
+	let is_selected = $derived(
+		svedit.session.selection?.type === 'property' &&
+			paths_equal(path, svedit.session.selection.path)
+	);
+	let owner_split = $derived(split_property_path_str(path_str));
+	let near_indices = $derived(
+		owner_split ? svedit.visibility_registry?.get_array_indices(owner_split.array_path) : null
+	);
+	let anchored = $derived(
+		!svedit.editable ||
+			is_selected ||
+			!owner_split ||
+			!near_indices ||
+			near_indices.has(owner_split.index)
+	);
+	let anchor_style = $derived(anchored ? `anchor-name: --${path_str};` : '');
 </script>
 
 <svelte:element
@@ -12,7 +46,7 @@
 	class={css_class}
 	data-type="property"
 	data-path={path_str}
-	style="anchor-name: --{path_str};{style ? ` ${style}` : ''}"
+	style="{anchor_style}{style ? ` ${style}` : ''}"
 	{...rest}
 >
 	<div class="property-selectable">

--- a/src/lib/Node.svelte
+++ b/src/lib/Node.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { getContext } from 'svelte';
 	import { serialize_path } from './utils.js';
-	import { split_node_path_str } from './node_visibility.svelte.js';
+	import { create_anchor_gate } from './node_visibility.svelte.js';
 	import type {
 		NodeArrayAttachmentContext,
 		NodeArrayRenderContext,
@@ -16,27 +16,7 @@
 	let node = $derived(svedit.session.get(path));
 	let path_str = $derived(serialize_path(path));
 
-	// Anchor culling. `anchor-name` registers a CSS anchor, and the
-	// browser's anchor bookkeeping runs on every layout pass and every
-	// native selection update, scaling with the number of registered
-	// anchors — at 2000 nodes it is the larger part of the cost of
-	// setting the caret after a keystroke. Same design as NodeGap's
-	// `.positioned`: while editable, only nodes near the viewport
-	// (overscan IO) register their anchor; scrolling moves the window
-	// and anchors follow. View mode keeps every anchor, so app overlays
-	// that anchor to arbitrary off-screen blocks (e.g. comment layers)
-	// see no change. Two-derived split as in NodeGap: get_array_indices
-	// lazily creates the set and Svelte doesn't track deps on state
-	// created inside the reading derived — acquire here, read in
-	// `anchored`.
-	let array_split = $derived(split_node_path_str(path_str));
-	let near_indices = $derived(
-		array_split ? svedit.visibility_registry.get_array_indices(array_split.array_path) : null
-	);
-	let anchored = $derived(
-		!svedit.editable || !array_split || !near_indices || near_indices.has(array_split.index)
-	);
-	let anchor_style = $derived(anchored ? `anchor-name: --${path_str};` : '');
+	const anchor = create_anchor_gate(svedit, () => path_str, 'node');
 
 	const node_array_meta = getContext<NodeArrayRenderContext | undefined>('node_array_meta');
 	let child_index = $derived(node_array_meta ? (path.at(-1) as number) : -1);
@@ -78,7 +58,7 @@
 	data-node-id={node.id}
 	data-path={path_str}
 	data-type="node"
-	style="{anchor_style}{style}"
+	style="{anchor.style}{style}"
 	{...rest}
 	{@attach svedit.visibility_registry.track_node(path_str)}
 >

--- a/src/lib/Node.svelte
+++ b/src/lib/Node.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { getContext } from 'svelte';
 	import { serialize_path } from './utils.js';
+	import { split_node_path_str } from './node_visibility.svelte.js';
 	import type {
 		NodeArrayAttachmentContext,
 		NodeArrayRenderContext,
@@ -14,6 +15,28 @@
 
 	let node = $derived(svedit.session.get(path));
 	let path_str = $derived(serialize_path(path));
+
+	// Anchor culling. `anchor-name` registers a CSS anchor, and the
+	// browser's anchor bookkeeping runs on every layout pass and every
+	// native selection update, scaling with the number of registered
+	// anchors — at 2000 nodes it is the larger part of the cost of
+	// setting the caret after a keystroke. Same design as NodeGap's
+	// `.positioned`: while editable, only nodes near the viewport
+	// (overscan IO) register their anchor; scrolling moves the window
+	// and anchors follow. View mode keeps every anchor, so app overlays
+	// that anchor to arbitrary off-screen blocks (e.g. comment layers)
+	// see no change. Two-derived split as in NodeGap: get_array_indices
+	// lazily creates the set and Svelte doesn't track deps on state
+	// created inside the reading derived — acquire here, read in
+	// `anchored`.
+	let array_split = $derived(split_node_path_str(path_str));
+	let near_indices = $derived(
+		array_split ? svedit.visibility_registry.get_array_indices(array_split.array_path) : null
+	);
+	let anchored = $derived(
+		!svedit.editable || !array_split || !near_indices || near_indices.has(array_split.index)
+	);
+	let anchor_style = $derived(anchored ? `anchor-name: --${path_str};` : '');
 
 	const node_array_meta = getContext<NodeArrayRenderContext | undefined>('node_array_meta');
 	let child_index = $derived(node_array_meta ? (path.at(-1) as number) : -1);
@@ -55,7 +78,7 @@
 	data-node-id={node.id}
 	data-path={path_str}
 	data-type="node"
-	style="anchor-name: --{path_str};{style}"
+	style="{anchor_style}{style}"
 	{...rest}
 	{@attach svedit.visibility_registry.track_node(path_str)}
 >

--- a/src/lib/NodeGapMarkers.svelte
+++ b/src/lib/NodeGapMarkers.svelte
@@ -56,10 +56,6 @@
 		const anchor_prefix = `--${path_str}`;
 		const g_prefix = `--g-${path_str}`;
 		const container_var = `;--_c:${anchor_prefix}`;
-		const has_pair = count >= 2;
-		const pair_vars = has_pair
-			? `;--_f:${anchor_prefix}${PATH_SEPARATOR}0;--_s:${anchor_prefix}${PATH_SEPARATOR}1`
-			: '';
 
 		type GapMarker = {
 			key: string;
@@ -97,6 +93,31 @@
 		}
 		sorted.sort((a, b) => a - b);
 		if (sorted.length === 0) return result;
+
+		// Row-gap narrowing (--_f/--_s) samples the spacing between ONE
+		// adjacent pair of items; spacing is uniform per array, so any
+		// adjacent pair measures the same gap. The pair must come from the
+		// near set: anchor culling (see Node.svelte) only registers
+		// anchors for near-viewport nodes, so referencing items 0/1
+		// unconditionally dangles once the array's head scrolls out of the
+		// overscan — and one dangling anchor() invalidates the whole inset
+		// declaration (IACVT), collapsing every marker of the array to a
+		// zero-width sliver at the containing block's left edge. Mid
+		// markers always have a near pair (they only render between two
+		// near nodes); when no adjacent pair is near, only edge markers
+		// can render and the `.pair` class gate skips their narrowing
+		// rules entirely.
+		let pair: [number, number] | null = null;
+		for (let i = 0; i < sorted.length - 1; i++) {
+			if (sorted[i + 1] === sorted[i] + 1) {
+				pair = [sorted[i], sorted[i + 1]];
+				break;
+			}
+		}
+		const has_pair = pair !== null;
+		const pair_vars = pair
+			? `;--_f:${anchor_prefix}${PATH_SEPARATOR}${pair[0]};--_s:${anchor_prefix}${PATH_SEPARATOR}${pair[1]}`
+			: '';
 
 		const offsets: number[] = [];
 		function add_offset(offset: number) {
@@ -304,18 +325,16 @@
 		top: min(
 			calc(anchor(var(--_p) bottom) + var(--_R) * 9999999px),
 			calc(
-				(anchor(var(--_p) bottom) + anchor(var(--_n) top)) / 2
-				- var(--_gm) / 2
-				+ var(--_R) * 9999999px
+				(anchor(var(--_p) bottom) + anchor(var(--_n) top)) / 2 - var(--_gm) / 2 + var(--_R) *
+					9999999px
 			),
 			calc(anchor(var(--_p) top) + var(--_C) * 9999999px)
 		);
 		bottom: min(
 			calc(anchor(var(--_n) top) + var(--_R) * 9999999px),
 			calc(
-				(anchor(var(--_p) bottom) + anchor(var(--_n) top)) / 2
-				- var(--_gm) / 2
-				+ var(--_R) * 9999999px
+				(anchor(var(--_p) bottom) + anchor(var(--_n) top)) / 2 - var(--_gm) / 2 + var(--_R) *
+					9999999px
 			),
 			calc(anchor(var(--_p) bottom) + var(--_C) * 9999999px)
 		);
@@ -323,25 +342,19 @@
 			calc(anchor(var(--_p) left) + var(--_R) * 9999999px),
 			calc(anchor(var(--_p) right) + var(--_C) * 9999999px),
 			calc(
-				(anchor(var(--_p) right) + anchor(var(--_n) left)) / 2
-				- var(--_gm) / 2
-				+ max(0px, anchor(var(--_p) right) - anchor(var(--_n) left)) * 9999
-				+ var(--_C) * 9999999px
+				(anchor(var(--_p) right) + anchor(var(--_n) left)) / 2 - var(--_gm) / 2 +
+					max(0px, anchor(var(--_p) right) - anchor(var(--_n) left)) * 9999 + var(--_C) * 9999999px
 			),
 			/* Wrap narrowing: centers marker in a gap-width region at prev_right.
 			   The + 0.5px disables this branch for zero-gap grids (items touching)
 			   where gap/2 - max(gap,--_gm)/2 would incorrectly shift left by 8px. */
 			calc(
-				anchor(var(--_p) right)
-				+ (max(0px, anchor(var(--_s) left) - anchor(var(--_f) right))) / 2
-				- max(
-					max(0px, anchor(var(--_s) left) - anchor(var(--_f) right)),
-					var(--_gm)
-				) / 2
-				+ max(0px, anchor(var(--_n) left) - anchor(var(--_p) right)) * 9999
-				+ max(0px, anchor(var(--_f) right) - anchor(var(--_s) left) + 0.5px) * 9999
-				+ var(--_C) * 9999999px
-			),
+					anchor(var(--_p) right) + (max(0px, anchor(var(--_s) left) - anchor(var(--_f) right))) /
+						2 - max(max(0px, anchor(var(--_s) left) - anchor(var(--_f) right)), var(--_gm)) / 2 +
+						max(0px, anchor(var(--_n) left) - anchor(var(--_p) right)) * 9999 +
+						max(0px, anchor(var(--_f) right) - anchor(var(--_s) left) + 0.5px) * 9999 + var(--_C) *
+						9999999px
+				),
 			/* Safety clamp for wrap: pins marker inside CB when prev/next wrap
 			   across rows (so the marker ends at the right edge of row 1).
 			   Disabled in nowrap/horizontal-scroll where p and n are
@@ -349,22 +362,18 @@
 			   position correctly and this clamp would wrongly force the
 			   marker to the CB right. */
 			calc(
-				100% - var(--_gm)
-				+ max(0px, anchor(var(--_n) left) - anchor(var(--_p) right) + 0.5px) * 9999
-				+ var(--_C) * 9999999px
-			),
+					100% - var(--_gm) + max(0px, anchor(var(--_n) left) - anchor(var(--_p) right) + 0.5px) *
+						9999 + var(--_C) * 9999999px
+				),
 			calc(
-				100% - max(
-					max(0px, anchor(var(--_s) left) - anchor(var(--_f) right)),
-					var(--_gm)
-				)
-				+ max(0px,
-					(max(0px, anchor(var(--_s) left) - anchor(var(--_f) right)))
-					- (anchor(var(--_c) right) - anchor(var(--_p) right))
-					- 0.5px
-				) * 9999
-				+ max(0px, anchor(var(--_n) left) - anchor(var(--_p) right)) * 9999
-				+ var(--_C) * 9999999px
+				100% - max(max(0px, anchor(var(--_s) left) - anchor(var(--_f) right)), var(--_gm)) +
+					max(
+						0px,
+						(max(0px, anchor(var(--_s) left) - anchor(var(--_f) right))) -
+							(anchor(var(--_c) right) - anchor(var(--_p) right)) - 0.5px
+					) *
+					9999 + max(0px, anchor(var(--_n) left) - anchor(var(--_p) right)) * 9999 + var(--_C) *
+					9999999px
 			)
 		);
 		right: max(
@@ -374,52 +383,45 @@
 			   case the marker must extend past CB right to reach the gap,
 			   so right must be allowed to go negative. */
 			calc(
-				0px + var(--_C) * -9999999px
-				- max(0px, anchor(var(--_p) right) - anchor(var(--_n) left) + 0.5px) * 9999
-			),
+					0px + var(--_C) * -9999999px -
+						max(0px, anchor(var(--_p) right) - anchor(var(--_n) left) + 0.5px) * 9999
+				),
 			min(
 				calc(anchor(var(--_p) right) + var(--_R) * 9999999px),
+				calc(anchor(var(--_n) left) + var(--_C) * 9999999px),
 				calc(
-					anchor(var(--_n) left) + var(--_C) * 9999999px
-				),
-				calc(
-					(anchor(var(--_p) right) + anchor(var(--_n) left)) / 2
-					- var(--_gm) / 2
-					+ var(--_C) * 9999999px
+					(anchor(var(--_p) right) + anchor(var(--_n) left)) / 2 - var(--_gm) / 2 + var(--_C) *
+						9999999px
 				),
 				max(
 					/* Symmetric right-side narrowing. The + 0.5px mirrors the left
 					   fix: disables for zero-gap grids to prevent 8px inward shift. */
 					calc(
-						anchor(var(--_p) right)
-						- (
-							max(0px, anchor(var(--_f) right) - anchor(var(--_s) left))
-							+ max(
-								max(0px, anchor(var(--_f) right) - anchor(var(--_s) left)),
-								var(--_gm)
-							)
-						) / 2
-						- max(0px, anchor(var(--_s) left) - anchor(var(--_f) right) + 0.5px) * 9999
-						+ var(--_C) * 9999999px
+							anchor(var(--_p) right) -
+								(
+									max(0px, anchor(var(--_f) right) - anchor(var(--_s) left)) +
+										max(max(0px, anchor(var(--_f) right) - anchor(var(--_s) left)), var(--_gm))
+								) /
+								2 - max(0px, anchor(var(--_s) left) - anchor(var(--_f) right) + 0.5px) * 9999 +
+								var(--_C) * 9999999px
+						),
+					calc(
+						anchor(var(--_p) right) - var(--_gm) -
+							max(
+								0px,
+								(anchor(var(--_p) right) - anchor(var(--_c) right)) -
+									(max(0px, anchor(var(--_f) right) - anchor(var(--_s) left))) + 0.5px
+							) *
+							9999 + var(--_C) * 9999999px
 					),
 					calc(
-						anchor(var(--_p) right) - var(--_gm)
-						- max(0px,
-							(anchor(var(--_p) right) - anchor(var(--_c) right))
-							- (max(0px, anchor(var(--_f) right) - anchor(var(--_s) left)))
-							+ 0.5px
-						) * 9999
-						+ var(--_C) * 9999999px
+						anchor(var(--_p) right) - var(--_gm) -
+							max(0px, anchor(var(--_f) right) - anchor(var(--_s) left)) * 9999 + var(--_C) *
+							9999999px
 					),
 					calc(
-						anchor(var(--_p) right) - var(--_gm)
-						- max(0px, anchor(var(--_f) right) - anchor(var(--_s) left)) * 9999
-						+ var(--_C) * 9999999px
-					),
-					calc(
-						anchor(var(--_p) right)
-						- (anchor(var(--_n) left) - anchor(var(--_p) right)) * 9999
-						+ var(--_C) * 9999999px
+						anchor(var(--_p) right) - (anchor(var(--_n) left) - anchor(var(--_p) right)) * 9999 +
+							var(--_C) * 9999999px
 					),
 					min(
 						calc(anchor(var(--_c) right) + var(--_C) * 9999999px),
@@ -441,8 +443,14 @@
 
 	/* Edge first: column = above first node, row = left of first node */
 	.gap-edge.first {
-		--_b-t: anchor(var(--node-caret-boundary-y, var(--node-caret-boundary, --_no-boundary)) top, 0px);
-		--_b-l: anchor(var(--node-caret-boundary-x, var(--node-caret-boundary, --_no-boundary)) left, 0px);
+		--_b-t: anchor(
+			var(--node-caret-boundary-y, var(--node-caret-boundary, --_no-boundary)) top,
+			0px
+		);
+		--_b-l: anchor(
+			var(--node-caret-boundary-x, var(--node-caret-boundary, --_no-boundary)) left,
+			0px
+		);
 		top: min(
 			calc(anchor(var(--_a) top) + var(--_C) * 9999999px),
 			calc(max(var(--_b-t), calc(anchor(var(--_a) top) - var(--_gm))) + var(--_R) * 9999999px)
@@ -466,18 +474,25 @@
 	   (which win over bottom/right in overconstrained abs-pos) cannot
 	   push the element past the boundary. */
 	.gap-edge.last {
-		--_b-b: anchor(var(--node-caret-boundary-y, var(--node-caret-boundary, --_no-boundary)) bottom, 0px);
-		--_b-r: anchor(var(--node-caret-boundary-x, var(--node-caret-boundary, --_no-boundary)) right, 0px);
-		--_b-bt: anchor(var(--node-caret-boundary-y, var(--node-caret-boundary, --_no-boundary)) bottom, 9999999px);
-		--_b-rl: anchor(var(--node-caret-boundary-x, var(--node-caret-boundary, --_no-boundary)) right, 9999999px);
+		--_b-b: anchor(
+			var(--node-caret-boundary-y, var(--node-caret-boundary, --_no-boundary)) bottom,
+			0px
+		);
+		--_b-r: anchor(
+			var(--node-caret-boundary-x, var(--node-caret-boundary, --_no-boundary)) right,
+			0px
+		);
+		--_b-bt: anchor(
+			var(--node-caret-boundary-y, var(--node-caret-boundary, --_no-boundary)) bottom,
+			9999999px
+		);
+		--_b-rl: anchor(
+			var(--node-caret-boundary-x, var(--node-caret-boundary, --_no-boundary)) right,
+			9999999px
+		);
 		top: min(
 			calc(anchor(var(--_a) top) + var(--_C) * 9999999px),
-			calc(
-				min(
-					anchor(var(--_a) bottom),
-					calc(var(--_b-bt) - var(--_gm))
-				) + var(--_R) * 9999999px
-			)
+			calc(min(anchor(var(--_a) bottom), calc(var(--_b-bt) - var(--_gm))) + var(--_R) * 9999999px)
 		);
 		bottom: min(
 			calc(anchor(var(--_a) bottom) + var(--_C) * 9999999px),
@@ -485,12 +500,7 @@
 		);
 		left: min(
 			calc(anchor(var(--_a) left) + var(--_R) * 9999999px),
-			calc(
-				min(
-					anchor(var(--_a) right),
-					calc(var(--_b-rl) - var(--_gm))
-				) + var(--_C) * 9999999px
-			),
+			calc(min(anchor(var(--_a) right), calc(var(--_b-rl) - var(--_gm))) + var(--_C) * 9999999px),
 			calc(100% - var(--_gm) + var(--_C) * 9999999px)
 		);
 		right: max(
@@ -520,15 +530,11 @@
 			calc(anchor(var(--_a) right) + var(--_C) * 9999999px),
 			calc(var(--_b-rl) - var(--_gm) + var(--_C) * 9999999px),
 			calc(
-				anchor(var(--_a) right)
-				+ (max(0px, anchor(var(--_s) left) - anchor(var(--_f) right))) / 2
-				- max(
-					max(0px, anchor(var(--_s) left) - anchor(var(--_f) right)),
-					var(--_gm)
-				) / 2
-				+ max(0px, anchor(var(--_f) right) - anchor(var(--_s) left)) * 9999
-				+ max(0px, anchor(var(--_a) right) - anchor(var(--_c) right) + 0.5px) * 9999
-				+ var(--_C) * 9999999px
+				anchor(var(--_a) right) + (max(0px, anchor(var(--_s) left) - anchor(var(--_f) right))) / 2 -
+					max(max(0px, anchor(var(--_s) left) - anchor(var(--_f) right)), var(--_gm)) / 2 +
+					max(0px, anchor(var(--_f) right) - anchor(var(--_s) left)) * 9999 +
+					max(0px, anchor(var(--_a) right) - anchor(var(--_c) right) + 0.5px) * 9999 + var(--_C) *
+					9999999px
 			),
 			/* Safety clamp for wrap: pins marker inside CB when items 0 and 1
 			   wrap across rows. Disabled in nowrap/horizontal-scroll where
@@ -536,52 +542,44 @@
 			   anchor-based branches position correctly and this clamp would
 			   wrongly force the marker to the CB right. */
 			calc(
-				100% - var(--_gm)
-				+ max(0px, anchor(var(--_s) left) - anchor(var(--_f) right) + 0.5px) * 9999
-				+ var(--_C) * 9999999px
-			),
+					100% - var(--_gm) + max(0px, anchor(var(--_s) left) - anchor(var(--_f) right) + 0.5px) *
+						9999 + var(--_C) * 9999999px
+				),
 			calc(
-				100% - max(
-					max(0px, anchor(var(--_s) left) - anchor(var(--_f) right)),
-					var(--_gm)
-				)
-				+ max(0px,
-					(max(0px, anchor(var(--_s) left) - anchor(var(--_f) right)))
-					- (anchor(var(--_c) right) - anchor(var(--_a) right))
-					- 0.5px
-				) * 9999
-				+ var(--_C) * 9999999px
+				100% - max(max(0px, anchor(var(--_s) left) - anchor(var(--_f) right)), var(--_gm)) +
+					max(
+						0px,
+						(max(0px, anchor(var(--_s) left) - anchor(var(--_f) right))) -
+							(anchor(var(--_c) right) - anchor(var(--_a) right)) - 0.5px
+					) *
+					9999 + var(--_C) * 9999999px
 			)
 		);
 		right: max(
 			calc(anchor(var(--_a) right) + var(--_R) * -9999999px),
 			calc(var(--_b-r) + var(--_C) * -9999999px),
 			calc(
-				anchor(var(--_a) right)
-				- (
-					max(0px, anchor(var(--_f) right) - anchor(var(--_s) left))
-					+ max(
-						max(0px, anchor(var(--_f) right) - anchor(var(--_s) left)),
-						var(--_gm)
-					)
-				) / 2
-				- max(0px, anchor(var(--_s) left) - anchor(var(--_f) right)) * 9999
-				- max(0px, anchor(var(--_c) right) - anchor(var(--_a) right) + 0.5px) * 9999
-				+ var(--_C) * -9999999px
+				anchor(var(--_a) right) -
+					(
+						max(0px, anchor(var(--_f) right) - anchor(var(--_s) left)) +
+							max(max(0px, anchor(var(--_f) right) - anchor(var(--_s) left)), var(--_gm))
+					) /
+					2 - max(0px, anchor(var(--_s) left) - anchor(var(--_f) right)) * 9999 -
+					max(0px, anchor(var(--_c) right) - anchor(var(--_a) right) + 0.5px) * 9999 + var(--_C) *
+					-9999999px
 			),
 			calc(
-				anchor(var(--_a) right) - var(--_gm)
-				- max(0px,
-					(anchor(var(--_a) right) - anchor(var(--_c) right))
-					- (max(0px, anchor(var(--_f) right) - anchor(var(--_s) left)))
-					+ 0.5px
-				) * 9999
-				+ var(--_C) * -9999999px
+				anchor(var(--_a) right) - var(--_gm) -
+					max(
+						0px,
+						(anchor(var(--_a) right) - anchor(var(--_c) right)) -
+							(max(0px, anchor(var(--_f) right) - anchor(var(--_s) left))) + 0.5px
+					) *
+					9999 + var(--_C) * -9999999px
 			),
 			calc(
-				anchor(var(--_a) right) - var(--_gm)
-				- max(0px, anchor(var(--_f) right) - anchor(var(--_s) left)) * 9999
-				+ var(--_C) * -9999999px
+				anchor(var(--_a) right) - var(--_gm) -
+					max(0px, anchor(var(--_f) right) - anchor(var(--_s) left)) * 9999 + var(--_C) * -9999999px
 			),
 			min(
 				calc(anchor(var(--_c) right) + var(--_C) * -9999999px),
@@ -598,7 +596,9 @@
 		&::before {
 			content: '';
 			position: absolute;
-			--gap-center: calc( var(--node-caret-symbol-size, 6px) / 2 + var(--node-caret-symbol-gap, 4px) );
+			--gap-center: calc(
+				var(--node-caret-symbol-size, 6px) / 2 + var(--node-caret-symbol-gap, 4px)
+			);
 		}
 
 		/* Dashed line: horizontal (column) or vertical (row).
@@ -607,27 +607,15 @@
 		   No explicit height/width — inset pairs control dimensions. */
 		&:not(.gap-empty)::before {
 			--_mi: var(--node-caret-marker-inset, 2px);
-			top: min(
-				calc(50% + var(--_R) * 9999999px),
-				calc(var(--_mi) + var(--_C) * 9999999px)
-			);
-			bottom: min(
-				calc(50% + var(--_R) * 9999999px),
-				calc(var(--_mi) + var(--_C) * 9999999px)
-			);
-			left: min(
-				calc(var(--_mi) + var(--_R) * 9999999px),
-				calc(50% + var(--_C) * 9999999px)
-			);
-			right: min(
-				calc(var(--_mi) + var(--_R) * 9999999px),
-				calc(50% + var(--_C) * 9999999px)
-			);
-			border-top: calc(var(--_C) * 1px) dashed var(--node-caret-gap-color, var(--svedit-canvas-stroke));
-			border-left: calc(var(--_R) * 1px) dashed var(--node-caret-gap-color, var(--svedit-canvas-stroke));
-			transform:
-				translateY(calc(var(--_C) * -0.5px))
-				translateX(calc(var(--_R) * -0.5px));
+			top: min(calc(50% + var(--_R) * 9999999px), calc(var(--_mi) + var(--_C) * 9999999px));
+			bottom: min(calc(50% + var(--_R) * 9999999px), calc(var(--_mi) + var(--_C) * 9999999px));
+			left: min(calc(var(--_mi) + var(--_R) * 9999999px), calc(50% + var(--_C) * 9999999px));
+			right: min(calc(var(--_mi) + var(--_R) * 9999999px), calc(50% + var(--_C) * 9999999px));
+			border-top: calc(var(--_C) * 1px) dashed
+				var(--node-caret-gap-color, var(--svedit-canvas-stroke));
+			border-left: calc(var(--_R) * 1px) dashed
+				var(--node-caret-gap-color, var(--svedit-canvas-stroke));
+			transform: translateY(calc(var(--_C) * -0.5px)) translateX(calc(var(--_R) * -0.5px));
 			mask-image: radial-gradient(
 				circle at center,
 				transparent calc(var(--gap-center) - 0.5px),
@@ -638,7 +626,10 @@
 		/* Empty array marker (dashed outline for discoverability). */
 		&.gap-empty::before {
 			inset: 0px;
-			border: var(--node-caret-empty-border, 1px dashed var(--node-caret-gap-color, var(--svedit-canvas-stroke)));
+			border: var(
+				--node-caret-empty-border,
+				1px dashed var(--node-caret-gap-color, var(--svedit-canvas-stroke))
+			);
 			border-radius: var(--node-caret-empty-border-radius, 3px);
 		}
 
@@ -651,8 +642,12 @@
 			top: 50%;
 			left: 50%;
 			transform: translate(-50%, -50%);
-			background: var(--node-caret-symbol-bg, var(--node-caret-gap-color, var(--svedit-canvas-stroke)));
-			mask: var(--node-caret-symbol-mask,
+			background: var(
+				--node-caret-symbol-bg,
+				var(--node-caret-gap-color, var(--svedit-canvas-stroke))
+			);
+			mask: var(
+				--node-caret-symbol-mask,
 				linear-gradient(black, black) center / 100% var(--node-caret-symbol-stroke, 1px) no-repeat,
 				linear-gradient(black, black) center / var(--node-caret-symbol-stroke, 1px) 100% no-repeat
 			);

--- a/src/lib/NodeGapMarkers.svelte
+++ b/src/lib/NodeGapMarkers.svelte
@@ -94,19 +94,12 @@
 		sorted.sort((a, b) => a - b);
 		if (sorted.length === 0) return result;
 
-		// Row-gap narrowing (--_f/--_s) samples the spacing between ONE
-		// adjacent pair of items; spacing is uniform per array, so any
-		// adjacent pair measures the same gap. The pair must come from the
-		// near set: anchor culling (see Node.svelte) only registers
-		// anchors for near-viewport nodes, so referencing items 0/1
-		// unconditionally dangles once the array's head scrolls out of the
-		// overscan — and one dangling anchor() invalidates the whole inset
-		// declaration (IACVT), collapsing every marker of the array to a
-		// zero-width sliver at the containing block's left edge. Mid
-		// markers always have a near pair (they only render between two
-		// near nodes); when no adjacent pair is near, only edge markers
-		// can render and the `.pair` class gate skips their narrowing
-		// rules entirely.
+		// Row-gap narrowing (--_f/--_s) samples the spacing of one adjacent
+		// pair — spacing is uniform per array. Must be a NEAR pair: culled
+		// nodes have no anchor (see create_anchor_gate), and one dangling
+		// anchor() invalidates the whole inset declaration, collapsing the
+		// marker to a zero-width sliver. Without a near pair only edge
+		// markers render, and their `.pair` gate skips the narrowing rules.
 		let pair: [number, number] | null = null;
 		for (let i = 0; i < sorted.length - 1; i++) {
 			if (sorted[i + 1] === sorted[i] + 1) {

--- a/src/lib/NodeSelectionMarkers.svelte
+++ b/src/lib/NodeSelectionMarkers.svelte
@@ -20,13 +20,7 @@
 		return paths;
 	}
 
-	// Off-viewport nodes don't register an `anchor-name` while editable
-	// (anchor culling, see Node.svelte), so an overlay for a far-away
-	// selected node would have nothing to anchor to and fall back to a
-	// stray box. Render markers only for nodes that are near the
-	// viewport — exactly the ones whose anchors exist. Scrolling moves
-	// the near-set and the markers follow. Two-derived split: acquire
-	// the set here, read `has()` in the each-guard below.
+	// Only render overlays for near nodes
 	let selection_near_indices = $derived.by(() => {
 		const selection = svedit.session.selection;
 		if (selection?.type !== 'node') return null;

--- a/src/lib/NodeSelectionMarkers.svelte
+++ b/src/lib/NodeSelectionMarkers.svelte
@@ -19,6 +19,19 @@
 		}
 		return paths;
 	}
+
+	// Off-viewport nodes don't register an `anchor-name` while editable
+	// (anchor culling, see Node.svelte), so an overlay for a far-away
+	// selected node would have nothing to anchor to and fall back to a
+	// stray box. Render markers only for nodes that are near the
+	// viewport — exactly the ones whose anchors exist. Scrolling moves
+	// the near-set and the markers follow. Two-derived split: acquire
+	// the set here, read `has()` in the each-guard below.
+	let selection_near_indices = $derived.by(() => {
+		const selection = svedit.session.selection;
+		if (selection?.type !== 'node') return null;
+		return svedit.visibility_registry?.get_array_indices(serialize_path(selection.path)) ?? null;
+	});
 </script>
 
 {#if svedit.session.selection?.type === 'property'}
@@ -30,7 +43,9 @@
 
 {#if selected_node_paths}
 	{#each selected_node_paths as path (serialize_path(path))}
-		<div class="selected-node-overlay" style="position-anchor: --{serialize_path(path)};"></div>
+		{#if !selection_near_indices || selection_near_indices.has(path.at(-1) as number)}
+			<div class="selected-node-overlay" style="position-anchor: --{serialize_path(path)};"></div>
+		{/if}
 	{/each}
 {/if}
 

--- a/src/lib/TextProperty.svelte
+++ b/src/lib/TextProperty.svelte
@@ -8,7 +8,7 @@
 		get_selection_range,
 		calculate_fragment_ranges
 	} from './utils.js';
-	import { split_property_path_str } from './node_visibility.svelte.js';
+	import { create_anchor_gate } from './node_visibility.svelte.js';
 
 	import type {
 		TextPropertyProps,
@@ -37,26 +37,13 @@
 		);
 	});
 
-	// Anchor culling, same design as NodeGap's `.positioned` and Node's
-	// `anchored` (see the comment there): while editable, only text
-	// properties whose owning node is near the viewport register their
-	// `anchor-name`. The focused property always keeps its anchor — the
-	// selection can sit in a block the reader has scrolled away from,
-	// and overlays (toolbars, link popovers) anchor to it. View mode is
-	// unchanged. Two-derived split: acquire the set here, read in
-	// `anchored`.
-	let owner_split = $derived(split_property_path_str(path_str));
-	let near_indices = $derived(
-		owner_split ? svedit.visibility_registry?.get_array_indices(owner_split.array_path) : null
+	// The focused property keeps its anchor: toolbars and popovers target it even when scrolled off-screen.
+	const anchor = create_anchor_gate(
+		svedit,
+		() => path_str,
+		'property',
+		() => is_focused
 	);
-	let anchored = $derived(
-		!svedit.editable ||
-			is_focused ||
-			!owner_split ||
-			!near_indices ||
-			near_indices.has(owner_split.index)
-	);
-	let anchor_style = $derived(anchored ? `anchor-name: --${path_str};` : '');
 
 	let plain_text = $derived(svedit.session.get(path).content);
 	// A string has zero grapheme clusters iff it has zero code units, so a
@@ -154,7 +141,7 @@
 	this={tag}
 	data-type="text"
 	data-path={path_str}
-	style="{anchor_style}{style}"
+	style="{anchor.style}{style}"
 	class="text svedit-selectable {css_class}"
 	class:empty={is_empty}
 	class:focused={is_focused}

--- a/src/lib/TextProperty.svelte
+++ b/src/lib/TextProperty.svelte
@@ -8,6 +8,7 @@
 		get_selection_range,
 		calculate_fragment_ranges
 	} from './utils.js';
+	import { split_property_path_str } from './node_visibility.svelte.js';
 
 	import type {
 		TextPropertyProps,
@@ -35,6 +36,27 @@
 			svedit.session.selection?.type === 'text' && paths_equal(path, svedit.session.selection.path)
 		);
 	});
+
+	// Anchor culling, same design as NodeGap's `.positioned` and Node's
+	// `anchored` (see the comment there): while editable, only text
+	// properties whose owning node is near the viewport register their
+	// `anchor-name`. The focused property always keeps its anchor — the
+	// selection can sit in a block the reader has scrolled away from,
+	// and overlays (toolbars, link popovers) anchor to it. View mode is
+	// unchanged. Two-derived split: acquire the set here, read in
+	// `anchored`.
+	let owner_split = $derived(split_property_path_str(path_str));
+	let near_indices = $derived(
+		owner_split ? svedit.visibility_registry?.get_array_indices(owner_split.array_path) : null
+	);
+	let anchored = $derived(
+		!svedit.editable ||
+			is_focused ||
+			!owner_split ||
+			!near_indices ||
+			near_indices.has(owner_split.index)
+	);
+	let anchor_style = $derived(anchored ? `anchor-name: --${path_str};` : '');
 
 	let plain_text = $derived(svedit.session.get(path).content);
 	// A string has zero grapheme clusters iff it has zero code units, so a
@@ -132,7 +154,7 @@
 	this={tag}
 	data-type="text"
 	data-path={path_str}
-	style="anchor-name: --{path_str};{style}"
+	style="{anchor_style}{style}"
 	class="text svedit-selectable {css_class}"
 	class:empty={is_empty}
 	class:focused={is_focused}

--- a/src/lib/node_visibility.svelte.ts
+++ b/src/lib/node_visibility.svelte.ts
@@ -606,6 +606,54 @@ export type VisibilityRegistryApi = {
 	track_array(path: string): (el: Element) => () => void;
 };
 
+/** Containing array path + index of a node path; null for root-level paths. */
+function split_node_path_str(path_str: string): { array_path: string; index: number } | null {
+	const sep = path_str.lastIndexOf(PATH_SEPARATOR);
+	if (sep < 0) return null;
+	const index = parseInt(path_str.slice(sep + PATH_SEPARATOR.length), 10);
+	if (Number.isNaN(index)) return null;
+	return { array_path: path_str.slice(0, sep), index };
+}
+
+/**
+ * Gate for `anchor-name` registration. Anchor bookkeeping runs on every
+ * layout pass and native selection update and scales with the number of
+ * registered anchors, so while editable only paths whose owning node is
+ * in the overscan set keep theirs — same principle as NodeGap's
+ * `.positioned`. `keep` pins an anchor on regardless (the focused or
+ * selected path, which overlays target even off-screen). View mode
+ * registers every anchor: read-mode overlays may target any block.
+ */
+export function create_anchor_gate(
+	svedit: { editable: boolean; visibility_registry?: VisibilityRegistryApi },
+	path_str: () => string,
+	kind: 'node' | 'property',
+	keep?: () => boolean
+) {
+	const split = $derived.by(() => {
+		let s = path_str();
+		if (kind === 'property') {
+			// Strip the property segment; the owning node carries visibility.
+			const sep = s.lastIndexOf(PATH_SEPARATOR);
+			if (sep < 0) return null;
+			s = s.slice(0, sep);
+		}
+		return split_node_path_str(s);
+	});
+	// Acquired outside the reading derived (see should_position_gap).
+	const near = $derived(
+		split ? svedit.visibility_registry?.get_array_indices(split.array_path) : null
+	);
+	const anchored = $derived(
+		!svedit.editable || keep?.() === true || !split || !near || near.has(split.index)
+	);
+	return {
+		get style() {
+			return anchored ? `anchor-name: --${path_str()};` : '';
+		}
+	};
+}
+
 /**
  * Pure visibility check for a gap's `.positioned` class. NodeGap calls
  * this from a $derived, so the `near.has()` reads are tracked at
@@ -620,36 +668,6 @@ export type VisibilityRegistryApi = {
  *
  * @param near - near child indices of the array
  */
-/**
- * Splits a serialized node path into its containing array path and the
- * node's index in that array. Returns null when the last segment is not
- * a number — i.e. for root-level paths like `page_1`, which have no
- * containing array and therefore no visibility record.
- */
-export function split_node_path_str(
-	path_str: string
-): { array_path: string; index: number } | null {
-	const sep = path_str.lastIndexOf(PATH_SEPARATOR);
-	if (sep < 0) return null;
-	const index = parseInt(path_str.slice(sep + PATH_SEPARATOR.length), 10);
-	if (Number.isNaN(index)) return null;
-	return { array_path: path_str.slice(0, sep), index };
-}
-
-/**
- * Same as split_node_path_str, but for a PROPERTY path (`[...node_path,
- * property_name]`): strips the property segment first, then splits the
- * owning node's path. Used to look up the visibility record of the node
- * a text or custom property lives in.
- */
-export function split_property_path_str(
-	path_str: string
-): { array_path: string; index: number } | null {
-	const sep = path_str.lastIndexOf(PATH_SEPARATOR);
-	if (sep < 0) return null;
-	return split_node_path_str(path_str.slice(0, sep));
-}
-
 export function should_position_gap(
 	near: SvelteSet<number>,
 	edge_state: { first: boolean; last: boolean } | undefined,

--- a/src/lib/node_visibility.svelte.ts
+++ b/src/lib/node_visibility.svelte.ts
@@ -477,11 +477,7 @@ class VisibilityRegistry {
 	}
 
 	#split_path(path: string): { array_path: string; index: number } | null {
-		const sep = path.lastIndexOf(PATH_SEPARATOR);
-		if (sep < 0) return null;
-		const index = parseInt(path.slice(sep + PATH_SEPARATOR.length), 10);
-		if (Number.isNaN(index)) return null;
-		return { array_path: path.slice(0, sep), index };
+		return split_node_path_str(path);
 	}
 
 	/**
@@ -624,6 +620,36 @@ export type VisibilityRegistryApi = {
  *
  * @param near - near child indices of the array
  */
+/**
+ * Splits a serialized node path into its containing array path and the
+ * node's index in that array. Returns null when the last segment is not
+ * a number — i.e. for root-level paths like `page_1`, which have no
+ * containing array and therefore no visibility record.
+ */
+export function split_node_path_str(
+	path_str: string
+): { array_path: string; index: number } | null {
+	const sep = path_str.lastIndexOf(PATH_SEPARATOR);
+	if (sep < 0) return null;
+	const index = parseInt(path_str.slice(sep + PATH_SEPARATOR.length), 10);
+	if (Number.isNaN(index)) return null;
+	return { array_path: path_str.slice(0, sep), index };
+}
+
+/**
+ * Same as split_node_path_str, but for a PROPERTY path (`[...node_path,
+ * property_name]`): strips the property segment first, then splits the
+ * owning node's path. Used to look up the visibility record of the node
+ * a text or custom property lives in.
+ */
+export function split_property_path_str(
+	path_str: string
+): { array_path: string; index: number } | null {
+	const sep = path_str.lastIndexOf(PATH_SEPARATOR);
+	if (sep < 0) return null;
+	return split_node_path_str(path_str.slice(0, sep));
+}
+
 export function should_position_gap(
 	near: SvelteSet<number>,
 	edge_state: { first: boolean; last: boolean } | undefined,

--- a/src/test/gap_visibility.svelte.test.ts
+++ b/src/test/gap_visibility.svelte.test.ts
@@ -456,15 +456,10 @@ describe('NodeGap visibility & placement', () => {
 	});
 
 	describe('anchor culling at the document tail', () => {
-		// Regression: gap markers referenced the anchors of array items 0
-		// and 1 unconditionally (row-gap narrowing via --_f/--_s). Anchor
-		// culling only registers anchors for near-viewport nodes, so once
-		// the array's head scrolled out of the overscan zone those
-		// references dangled — and a dangling anchor() invalidates the
-		// whole inset declaration (IACVT), collapsing every marker of the
-		// array (and the node caret inside the active one) to a zero-width
-		// sliver at the containing block's left edge. The fix samples the
-		// pair from the near set instead.
+		// Regression: markers sampled --_f/--_s from items 0/1. With the
+		// head culled those anchors dangle, and one dangling anchor()
+		// invalidates the whole inset declaration — every marker (and the
+		// node caret) collapsed to a zero-width sliver at the left edge.
 		it('renders full-width markers and node caret at the tail while the head anchors are culled', async () => {
 			const session = make_tall_body_session(60);
 			const { container } = render(SveditTest, { session });

--- a/src/test/gap_visibility.svelte.test.ts
+++ b/src/test/gap_visibility.svelte.test.ts
@@ -19,6 +19,7 @@ import {
 	settle_grid,
 	make_story_session,
 	make_image_grid_session,
+	make_tall_body_session,
 	find_buttons_array,
 	find_image_grid_array,
 	find_last_gap,
@@ -197,7 +198,9 @@ describe('NodeGap visibility & placement', () => {
 			// sync_gap_class broke.
 			const last_gap = find_last_gap(array_el);
 			expect(last_gap).not.toBeNull();
-			const items = Array.from(array_el.querySelectorAll<HTMLElement>(':scope > [data-type="node"]'));
+			const items = Array.from(
+				array_el.querySelectorAll<HTMLElement>(':scope > [data-type="node"]')
+			);
 			const last_item = items[items.length - 1];
 			const li_rect = last_item.getBoundingClientRect();
 			const arr_rect = array_el.getBoundingClientRect();
@@ -332,7 +335,7 @@ describe('NodeGap visibility & placement', () => {
 			}
 
 			// Delete the button at offset 1 (mid).
-			const canvas = (container.querySelector('.svedit-canvas') as HTMLElement);
+			const canvas = container.querySelector('.svedit-canvas') as HTMLElement;
 			canvas.focus();
 			session.selection = {
 				type: 'node',
@@ -449,6 +452,76 @@ describe('NodeGap visibility & placement', () => {
 			array_el.style.maxWidth = '';
 			await settle();
 			expect(find_last_gap(array_el).classList.contains('positioned')).toBe(true);
+		});
+	});
+
+	describe('anchor culling at the document tail', () => {
+		// Regression: gap markers referenced the anchors of array items 0
+		// and 1 unconditionally (row-gap narrowing via --_f/--_s). Anchor
+		// culling only registers anchors for near-viewport nodes, so once
+		// the array's head scrolled out of the overscan zone those
+		// references dangled — and a dangling anchor() invalidates the
+		// whole inset declaration (IACVT), collapsing every marker of the
+		// array (and the node caret inside the active one) to a zero-width
+		// sliver at the containing block's left edge. The fix samples the
+		// pair from the near set instead.
+		it('renders full-width markers and node caret at the tail while the head anchors are culled', async () => {
+			const session = make_tall_body_session(60);
+			const { container } = render(SveditTest, { session });
+			await settle();
+
+			const body_el = container.querySelector<HTMLElement>(
+				'[data-type="node_array"][data-path="page_1__body"]'
+			);
+			expect(body_el).not.toBeNull();
+			const nodes = body_el!.querySelectorAll<HTMLElement>(':scope > [data-type="node"]');
+			expect(nodes.length).toBe(60);
+
+			// Scroll the tail into view so the head leaves the overscan zone.
+			nodes[nodes.length - 1].scrollIntoView({ block: 'center' });
+			await settle_grid();
+
+			// Guard against a vacuous pass: culling must have taken effect —
+			// the head node's near entry AND its anchor must be gone.
+			const ctx = (globalThis as any).__svedit_ctx_for_test;
+			const near = ctx.visibility_registry.get_array_indices('page_1__body');
+			expect(near.has(0)).toBe(false);
+			expect(getComputedStyle(nodes[0]).getPropertyValue('anchor-name')).toBe('none');
+
+			// Every rendered marker for the body array must have a real box.
+			const markers = container.querySelectorAll<HTMLElement>(
+				'.gap-marker[data-gap-array-path="page_1__body"]'
+			);
+			expect(markers.length).toBeGreaterThan(0);
+			for (const marker of markers) {
+				const rect = marker.getBoundingClientRect();
+				expect(rect.width, `marker at offset ${marker.dataset.gapOffset}`).toBeGreaterThan(100);
+			}
+
+			// The --_f/--_s pair vars must reference near indices, never the
+			// culled head.
+			for (const marker of markers) {
+				const style = marker.getAttribute('style') ?? '';
+				const f = style.match(/--_f:--page_1__body__(\d+)/);
+				if (f) {
+					expect(near.has(parseInt(f[1], 10)), `--_f references culled index ${f[1]}`).toBe(true);
+				}
+			}
+
+			// Node caret at a tail gap: the active marker (which hosts the
+			// caret) must have a real box too.
+			const tail_offset = nodes.length - 1;
+			session.selection = {
+				type: 'node',
+				path: ['page_1', 'body'],
+				anchor_offset: tail_offset,
+				focus_offset: tail_offset
+			};
+			await settle();
+			const active_marker = container.querySelector<HTMLElement>('.gap-marker.active');
+			expect(active_marker).not.toBeNull();
+			const active_rect = active_marker!.getBoundingClientRect();
+			expect(active_rect.width).toBeGreaterThan(100);
 		});
 	});
 

--- a/src/test/test_utils.ts
+++ b/src/test/test_utils.ts
@@ -117,6 +117,38 @@ export function make_image_grid_session(n_items: number) {
 	return new Session(document_schema, { document_id: 'page_1', nodes }, create_test_config());
 }
 
+/**
+ * Build a session whose root body holds `n` paragraphs, each tall enough
+ * that scrolling to the document tail pushes the head paragraphs out of
+ * the visibility registry's overscan zone (anchor culling takes effect).
+ */
+export function make_tall_body_session(n_paragraphs: number) {
+	const body_ids: string[] = [];
+	const nodes: Document['nodes'] = {};
+	const filler =
+		'A paragraph tall enough to give the document real height, so that scrolling to the end moves the first nodes well past the overscan margin and their anchors are culled. '.repeat(
+			3
+		);
+	for (let i = 0; i < n_paragraphs; i++) {
+		const id = `para_${i}`;
+		nodes[id] = {
+			id,
+			type: 'paragraph',
+			content: { content: `¶${i} ${filler}`, marks: [], annotations: [] }
+		};
+		body_ids.push(id);
+	}
+	nodes.page_1 = {
+		id: 'page_1',
+		type: 'page',
+		body: { nodes: body_ids, marks: [], annotations: [] },
+		keywords: [],
+		daily_visitors: [],
+		created_at: '2025-05-30T10:39:59.987Z'
+	};
+	return new Session(document_schema, { document_id: 'page_1', nodes }, create_test_config());
+}
+
 /** Find the (non-empty) buttons node-array inside the rendered tree. */
 export function find_buttons_array(container: HTMLElement) {
 	return container.querySelector<HTMLElement>(

--- a/src/test/test_utils.ts
+++ b/src/test/test_utils.ts
@@ -118,9 +118,8 @@ export function make_image_grid_session(n_items: number) {
 }
 
 /**
- * Build a session whose root body holds `n` paragraphs, each tall enough
- * that scrolling to the document tail pushes the head paragraphs out of
- * the visibility registry's overscan zone (anchor culling takes effect).
+ * Build a session with `n` root paragraphs, tall enough that scrolling
+ * to the tail pushes the head out of the overscan zone (anchor culling).
  */
 export function make_tall_body_session(n_paragraphs: number) {
 	const body_ids: string[] = [];


### PR DESCRIPTION

Every `Node`, `TextProperty`, and `CustomProperty` registers a CSS anchor (`anchor-name: --{path}`) unconditionally. The browser's anchor bookkeeping runs on every layout pass and every native selection update, and scales with the number of registered anchors. #329 established this for node gaps ("anchor positioning is O(N)") and gated gap anchors by viewport proximity; this PR extends the same gate to the remaining anchor populations.


**Changes**
- `Node`, `TextProperty`, `CustomProperty`: while `editable`, register `anchor-name` only when the owning node is in the overscan set (same source and two-derived pattern as NodeGap's `.positioned`). View mode is unchanged: every anchor registers, so read-mode overlays (comment layers etc.) are unaffected.
- Always anchored regardless of viewport: the focused text property and the property-selected custom property, since toolbars and selection overlays anchor to them even when scrolled off-screen.
- `NodeSelectionMarkers`: render overlays only for selected nodes in the overscan set, so no overlay targets a culled anchor. Select-all no longer creates one positioned element per document node; markers follow the near-set while scrolling.
- `node_visibility`: `split_node_path_str` / `split_property_path_str` exported (the private `#split_path` now delegates).


Positioned gaps already require both neighbor nodes in the same near-set, so gap markers always find their neighbor anchors; the two gates compose without coordination.

**Numbers** (perftest, 2,000 nodes, editable; A/B on the same machine, patch-independent transaction-apply time as clock control: 29.3 vs 31.8ms)

| | before | after |
|---|---|---|
| native `setBaseAndExtent` per keystroke | 30–50ms | **9.8ms** |
| render tick per keystroke | 135ms | **115ms** |
| full relayout step (resize) | 84ms | **48ms** |

Memory: the anchor registry shrinks from O(document) to O(viewport) (~2,000 → ~50 registered anchors at this scale) and giant node selections render ~15 overlays instead of 2,000. Both live in renderer internals, not the JS heap, so no script-measurable number; JS heap delta is noise.

**Considered and rejected:** skipping the selection re-render when the DOM selection already matches the model. Instrumented: it would fire on ~1 of 11 keystrokes, because Blink resets the caret to offset 0 when the text node's data is replaced. Nothing to skip on the hot path.

**Note for app authors:** in edit mode, overlays anchored to svedit path anchors should target the selection or something near the viewport. Existing consumers (toolbars, link popover, slash menus, selection markers) already do.

**Verification:** 124/124 unit tests, svelte-check and lint clean. Interactive checks with real input: typing, toolbar anchoring on text selection, node selection overlays including select-all, marker catch-up while scrolling mid-selection.